### PR TITLE
Add two status-bar toggles: Window-only capture and a Read-only permission lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This project follows [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **A Read-only status-bar toggle (◉ / ○ Read-only).** Switches the live session between
+  `"plan"` — Claude can see your screen, read files, and answer, but not edit anything or
+  run commands — and the configured `PERMISSION_MODE`, with no restart. The toggle only
+  flips once the CLI confirms the switch, and while read-only is on the overlay denies
+  every permission escalation the agent requests (including `ExitPlanMode`, which the
+  overlay's blanket auto-approval would otherwise grant — silently lifting read-only).
+  Set `PERMISSION_MODE = "plan"` to start locked; the mode also survives the overlay's
+  automatic reconnects.
 - **Screenshots can now capture just the active window instead of every monitor.** A new
   **◉ / ○ Window-only** status-bar toggle (startup default via `SHOT_SCOPE` /
   `CLAUDE_OVERLAY_SHOT_SCOPE`) scopes each capture to the window you're working in —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@ This project follows [Semantic Versioning](https://semver.org/).
   window's title is passed to Claude so it knows what it's looking at, and the visible
   frame is captured without the drop shadow. When no usable window exists (fresh
   launch, desktop focused, window minimized) it falls back to the normal full-screen
-  capture rather than sending nothing.
+  capture rather than sending nothing. The toggle remembers your choice across launches
+  (a tiny per-machine `state.json` under `%LOCALAPPDATA%\claude-overlay`); an explicitly
+  set `CLAUDE_OVERLAY_SHOT_SCOPE` env var overrides the memory for that launch.
 
 ## [1.11.4] — 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,11 @@ This project follows [Semantic Versioning](https://semver.org/).
   flips once the CLI confirms the switch, and while read-only is on the overlay denies
   every permission escalation the agent requests (including `ExitPlanMode`, which the
   overlay's blanket auto-approval would otherwise grant — silently lifting read-only).
-  Set `PERMISSION_MODE = "plan"` to start locked; the mode also survives the overlay's
+  Set `PERMISSION_MODE = "plan"` to start locked on first launch — the toggle remembers
+  your last choice across launches (same per-machine state store as Window-only, and a
+  remembered unlock launches the session directly in the full-access mode so it stays
+  bypass-capable); because that memory is a safety state, startup announces it in-chat
+  whenever it differs from the configured default. The mode also survives the overlay's
   automatic reconnects. When the session wasn't *launched* in `bypassPermissions` the
   CLI forbids elevating to it at run time, so unlocking lands on `acceptEdits` instead —
   effectively full access here, and the in-chat notice names the mode you actually got.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ This project follows [Semantic Versioning](https://semver.org/).
   every permission escalation the agent requests (including `ExitPlanMode`, which the
   overlay's blanket auto-approval would otherwise grant — silently lifting read-only).
   Set `PERMISSION_MODE = "plan"` to start locked; the mode also survives the overlay's
-  automatic reconnects.
+  automatic reconnects. When the session wasn't *launched* in `bypassPermissions` the
+  CLI forbids elevating to it at run time, so unlocking lands on `acceptEdits` instead —
+  effectively full access here, and the in-chat notice names the mode you actually got.
 - **Screenshots can now capture just the active window instead of every monitor.** A new
   **◉ / ○ Window-only** status-bar toggle (startup default via `SHOT_SCOPE` /
   `CLAUDE_OVERLAY_SHOT_SCOPE`) scopes each capture to the window you're working in —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to Claude Overlay are documented here.
 This project follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- **Screenshots can now capture just the active window instead of every monitor.** A new
+  **◉ / ○ Window-only** status-bar toggle (startup default via `SHOT_SCOPE` /
+  `CLAUDE_OVERLAY_SHOT_SCOPE`) scopes each capture to the window you're working in —
+  more private (Claude sees nothing outside that window) and much cheaper in vision
+  tokens on multi-monitor setups. Because the overlay itself has focus while you type,
+  it remembers the window you were in before summoning it and captures that one; the
+  window's title is passed to Claude so it knows what it's looking at, and the visible
+  frame is captured without the drop shadow. When no usable window exists (fresh
+  launch, desktop focused, window minimized) it falls back to the normal full-screen
+  capture rather than sending nothing.
+
 ## [1.11.4] — 2026-07-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ Double-click **`Create Desktop Shortcut.cmd`** to drop a **Claude Overlay** shor
 | Stop a running reply | click **Stop** (the ↑ becomes ■ while busy) |
 | Paste an image | **Ctrl+V** (click **📎** to clear) |
 | Toggle auto-screenshot | **◉ / ○ Auto-shot** (orange = on) |
+| Capture only the active window | **◉ / ○ Window-only** (orange = window-only; off = every monitor) |
 | Show / hide in screen shares | **◉ / ○ Shareable** (orange = visible to Teams/Zoom/OBS; off = private, the default) |
 | Switch model | click the **statusline** (`model ▾`) |
 | Zoom text in / out | **Ctrl +** / **Ctrl −** (or **Ctrl + mouse-wheel**); **Ctrl 0** resets |
@@ -310,6 +311,14 @@ All settings are constants at the top of `claude_overlay.py`:
 - `SHOT_FORMAT` / `SHOT_JPEG_QUALITY` (or the `CLAUDE_OVERLAY_SHOT_FORMAT` /
   `CLAUDE_OVERLAY_SHOT_JPEG_QUALITY` env vars) — screenshot payload: `"auto"` keeps
   the smaller of PNG/JPEG per capture; `"png"`/`"jpeg"` force one; JPEG quality 50–95.
+- `SHOT_SCOPE` (or the `CLAUDE_OVERLAY_SHOT_SCOPE` env var) — what a screenshot covers:
+  `"screens"` (default) captures every monitor, one image each; `"window"` captures
+  **only the active window** — more private and cheaper in vision tokens, but Claude
+  can't see anything outside it. This is just the startup default; flip it live with
+  the **◉ / ○ Window-only** status-bar toggle. While you're typing *in* the overlay,
+  "active" means the window you were working in before it (tracked automatically), and
+  when no usable window exists (fresh launch, desktop focused, window minimized) it
+  falls back to full-screen capture rather than sending nothing.
 - `AUTO_SCREENSHOT_DEFAULT`, `FONT_SANS/SERIF/MONO`, `CORNER_RADIUS`, `ORB_SIZE`,
   `HIDE_SCREENSHOT_TOOL`, `WINDOW_ALPHA` — see inline comments.
 

--- a/README.md
+++ b/README.md
@@ -318,7 +318,9 @@ All settings are constants at the top of `claude_overlay.py`:
   `"screens"` (default) captures every monitor, one image each; `"window"` captures
   **only the active window** — more private and cheaper in vision tokens, but Claude
   can't see anything outside it. This is just the startup default; flip it live with
-  the **◉ / ○ Window-only** status-bar toggle. While you're typing *in* the overlay,
+  the **◉ / ○ Window-only** status-bar toggle — and the toggle **remembers your choice
+  across launches** (stored per-machine in `%LOCALAPPDATA%\claude-overlay\state.json`;
+  setting the env var explicitly overrides it for that launch). While you're typing *in* the overlay,
   "active" means the window you were working in before it (tracked automatically), and
   when no usable window exists (fresh launch, desktop focused, window minimized) it
   falls back to full-screen capture rather than sending nothing.

--- a/README.md
+++ b/README.md
@@ -341,6 +341,10 @@ the **◉ / ○ Read-only** status-bar toggle: it switches the live session into
 mode (Claude looks, reads, and answers — but edits and runs nothing), and while it's
 on the overlay **denies every permission escalation the agent asks for** (including
 `ExitPlanMode`), so read-only can't be talked out of; flip it back for full access.
+(One nuance: the CLI refuses to elevate a session to `bypassPermissions` unless it was
+*launched* in it — so when the overlay started read-only, flipping the toggle off lands
+on `acceptEdits` instead, which the overlay's auto-approval makes effectively full
+access; the in-chat notice always names the mode you actually got.)
 To *start* locked, set `PERMISSION_MODE = "plan"`. (`"acceptEdits"` / `"default"` are
 of limited use here: a GUI with no terminal has nowhere to show a permission prompt,
 so the overlay auto-answers them — see `worker._allow_tool`.)

--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ Double-click **`Create Desktop Shortcut.cmd`** to drop a **Claude Overlay** shor
 | Toggle auto-screenshot | **◉ / ○ Auto-shot** (orange = on) |
 | Capture only the active window | **◉ / ○ Window-only** (orange = window-only; off = every monitor) |
 | Show / hide in screen shares | **◉ / ○ Shareable** (orange = visible to Teams/Zoom/OBS; off = private, the default) |
+| Lock Claude read-only | **◉ / ○ Read-only** (orange = "plan" mode: looks and answers, changes nothing; off = the configured `PERMISSION_MODE`) |
 | Switch model | click the **statusline** (`model ▾`) |
 | Zoom text in / out | **Ctrl +** / **Ctrl −** (or **Ctrl + mouse-wheel**); **Ctrl 0** resets |
 | New conversation | **Clear** |
@@ -298,8 +299,10 @@ All settings are constants at the top of `claude_overlay.py`:
   in-app switcher lists them all (the statusline shows the concrete version each alias
   resolved to, e.g. `claude-opus-4-8`). Don't use `None`: the Agent SDK resolves `None`
   to an older model, not the CLI's interactive default.
-- `PERMISSION_MODE` — `"bypassPermissions"` by default (see security note below).
-  Use `"acceptEdits"`, `"default"`, or `"plan"` to add confirmation / read-only.
+- `PERMISSION_MODE` — `"bypassPermissions"` by default (see security note below); this
+  is just the **startup** mode — the **◉ / ○ Read-only** status-bar toggle switches the
+  live session between `"plan"` (read-only) and this mode at any time. Set `"plan"` to
+  start locked read-only.
 - `WORKING_DIR` — folder Claude operates in (default: your home directory).
 - `THEME` — `"light"` (warm paper) or `"dark"`.
 - `TASKBAR_BUTTON` — `True` (default) gives the frameless window a real, clickable
@@ -331,9 +334,14 @@ also lets it **act on the app you have open** — e.g. edit the document or slid
 deck on your screen via Windows/COM automation, and (with autosave on) persist
 those edits straight to the original file. That's the magic, but it also means it
 can change important documents without a confirmation step — double-check before
-you let it loose on anything you can't afford to lose. If you don't want that, set
-`PERMISSION_MODE` to `"acceptEdits"` (asks before edits), `"default"` (asks before
-most actions), or `"plan"` (read-only) before running.
+you let it loose on anything you can't afford to lose. If you don't want that, flip
+the **◉ / ○ Read-only** status-bar toggle: it switches the live session into `"plan"`
+mode (Claude looks, reads, and answers — but edits and runs nothing), and while it's
+on the overlay **denies every permission escalation the agent asks for** (including
+`ExitPlanMode`), so read-only can't be talked out of; flip it back for full access.
+To *start* locked, set `PERMISSION_MODE = "plan"`. (`"acceptEdits"` / `"default"` are
+of limited use here: a GUI with no terminal has nowhere to show a permission prompt,
+so the overlay auto-answers them — see `worker._allow_tool`.)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -300,9 +300,11 @@ All settings are constants at the top of `claude_overlay.py`:
   resolved to, e.g. `claude-opus-4-8`). Don't use `None`: the Agent SDK resolves `None`
   to an older model, not the CLI's interactive default.
 - `PERMISSION_MODE` — `"bypassPermissions"` by default (see security note below); this
-  is just the **startup** mode — the **◉ / ○ Read-only** status-bar toggle switches the
-  live session between `"plan"` (read-only) and this mode at any time. Set `"plan"` to
-  start locked read-only.
+  is just the **first-launch** mode — the **◉ / ○ Read-only** status-bar toggle switches
+  the live session between `"plan"` (read-only) and this mode at any time, and the
+  toggle **remembers your last choice across launches** (announced in-chat at startup
+  whenever the remembered state differs from this default). Set `"plan"` to start
+  locked read-only.
 - `WORKING_DIR` — folder Claude operates in (default: your home directory).
 - `THEME` — `"light"` (warm paper) or `"dark"`.
 - `TASKBAR_BUTTON` — `True` (default) gives the frameless window a real, clickable
@@ -345,7 +347,9 @@ on the overlay **denies every permission escalation the agent asks for** (includ
 *launched* in it — so when the overlay started read-only, flipping the toggle off lands
 on `acceptEdits` instead, which the overlay's auto-approval makes effectively full
 access; the in-chat notice always names the mode you actually got.)
-To *start* locked, set `PERMISSION_MODE = "plan"`. (`"acceptEdits"` / `"default"` are
+To *start* locked on first launch, set `PERMISSION_MODE = "plan"` — after that the
+toggle's last state is remembered per-machine, and a launch says so in-chat whenever
+the remembered choice differs from the configured default. (`"acceptEdits"` / `"default"` are
 of limited use here: a GUI with no terminal has nowhere to show a permission prompt,
 so the overlay auto-answers them — see `worker._allow_tool`.)
 

--- a/claude_overlay.py
+++ b/claude_overlay.py
@@ -65,6 +65,32 @@ def _ensure_shot_dir():
         SHOT_DIR = Path(tempfile.gettempdir())
 
 
+def _load_state():
+    """Best-effort read of the tiny persisted UI state (STATE_FILE). Any problem —
+    missing, unreadable, not a dict, absurdly large — yields {} so startup can't break."""
+    try:
+        if STATE_FILE.stat().st_size > 64 * 1024:   # sanity cap; ours is tens of bytes
+            return {}
+        data = json.loads(STATE_FILE.read_text("utf-8"))
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _save_state(**updates):
+    """Merge updates into STATE_FILE (temp file + os.replace, so a crash mid-write can't
+    leave truncated JSON behind). Best-effort: persisting a toggle must never break the UI."""
+    try:
+        state = _load_state()
+        state.update(updates)
+        STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        tmp = STATE_FILE.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(state), "utf-8")
+        os.replace(tmp, STATE_FILE)
+    except Exception:
+        pass
+
+
 def round_rect(c, x1, y1, x2, y2, r, **kw):
     pts = [x1 + r, y1, x2 - r, y1, x2, y1, x2, y1 + r, x2, y2 - r, x2, y2,
            x2 - r, y2, x1 + r, y2, x1, y2, x1, y2 - r, x1, y1 + r, x1, y1]
@@ -80,6 +106,9 @@ class Overlay:
 
         self.auto_shot = AUTO_SCREENSHOT_DEFAULT
         self.window_shot = (SHOT_SCOPE == "window")   # True → capture only the active window
+        if not SHOT_SCOPE_FORCED:                     # remembered toggle choice survives a
+            self.window_shot = bool(_load_state().get("window_shot", self.window_shot))
+                                                      # relaunch; an explicit env var beats it
         self.share_visible = SHOW_IN_SCREEN_SHARE_DEFAULT   # True → overlay shows in screen shares
         self.read_only = (PERMISSION_MODE == "plan")  # True → agent may look, not act; the toggle
                                                       # flips it via the worker (confirmed async)
@@ -2914,6 +2943,7 @@ class Overlay:
         self.window_shot = not self.window_shot
         self._precaptured = None   # a frame grabbed under the OLD scope must not be sent
         self._paint_window_toggle()
+        _save_state(window_shot=self.window_shot)   # deliberate choice → survives relaunch
         if self.window_shot:
             self.add_sys("🎯 Screenshots now capture the ACTIVE WINDOW only "
                          "(falls back to full screen when no window is in focus).")

--- a/claude_overlay.py
+++ b/claude_overlay.py
@@ -91,6 +91,21 @@ def _save_state(**updates):
         pass
 
 
+def _startup_permission_mode():
+    """Decide this launch's permission state: (read_only, mode to LAUNCH the worker in).
+    The remembered Read-only toggle — a deliberate user choice, like Window-only — wins
+    over the config default; PERMISSION_MODE seeds the first launch (no saved state).
+    A remembered unlock launches straight in the full-access mode, so the session is
+    born bypass-capable when full access means bypassPermissions — a running session
+    can never be ELEVATED to bypass later (see worker._bypass_capable)."""
+    ro = (PERMISSION_MODE == "plan")
+    saved = _load_state().get("read_only")
+    if isinstance(saved, bool):
+        ro = saved
+    full = PERMISSION_MODE if PERMISSION_MODE != "plan" else "bypassPermissions"
+    return ro, ("plan" if ro else full)
+
+
 def round_rect(c, x1, y1, x2, y2, r, **kw):
     pts = [x1 + r, y1, x2 - r, y1, x2, y1, x2, y1 + r, x2, y2 - r, x2, y2,
            x2 - r, y2, x1 + r, y2, x1, y2, x1, y2 - r, x1, y1 + r, x1, y1]
@@ -101,7 +116,11 @@ class Overlay:
     def __init__(self):
         self.ui_q: "queue.Queue" = queue.Queue()
         _ensure_shot_dir()          # before the worker, so a bad TEMP can't crash us mid-startup
-        self.worker = ClaudeWorker(self.ui_q)
+        # Resolve the remembered Read-only toggle BEFORE the worker exists: the session
+        # must be LAUNCHED in the remembered mode (a plan-launched session can't be
+        # elevated to bypassPermissions at run time, only started in it).
+        self.read_only, _launch_mode = _startup_permission_mode()
+        self.worker = ClaudeWorker(self.ui_q, permission_mode=_launch_mode)
         self.worker.start()
 
         self.auto_shot = AUTO_SCREENSHOT_DEFAULT
@@ -110,8 +129,8 @@ class Overlay:
             self.window_shot = bool(_load_state().get("window_shot", self.window_shot))
                                                       # relaunch; an explicit env var beats it
         self.share_visible = SHOW_IN_SCREEN_SHARE_DEFAULT   # True → overlay shows in screen shares
-        self.read_only = (PERMISSION_MODE == "plan")  # True → agent may look, not act; the toggle
-                                                      # flips it via the worker (confirmed async)
+        # self.read_only was set above (worker launch); the toggle flips it via the
+        # worker (confirmed async) and each confirmed change is persisted.
         self._full_mode = (PERMISSION_MODE if PERMISSION_MODE != "plan"
                            else "bypassPermissions")  # what Read-only OFF returns to: the
                                                       # configured mode — unless that IS plan,
@@ -254,6 +273,13 @@ class Overlay:
         self._build_edges()        # invisible drag strips on every edge/corner → resize
         self._bind_zoom()          # Ctrl +/- and Ctrl+wheel → live text zoom
         self._intro()
+        # A remembered Read-only choice silently overriding the config default is a
+        # SAFETY state — say so up front, so a launch never surprises.
+        if self.read_only != (PERMISSION_MODE == "plan"):
+            self.add_sys("🔒 Read-only restored from your last session — flip the "
+                         "Read-only toggle off for full access." if self.read_only else
+                         "⚡ Full access restored from your last session (you had "
+                         "switched Read-only off). Flip it back on any time.")
 
         self.root.after(130, lambda: (self.root.focus_force(), self.entry.focus_set()))
         self.root.bind("<Configure>", self._on_configure)
@@ -2967,6 +2993,8 @@ class Overlay:
         changed = (ro != self.read_only)
         self.read_only = ro
         self._paint_ro_toggle()
+        if changed:
+            _save_state(read_only=ro)   # persist only CONFIRMED switches, never requests
         if changed and ro:
             self.add_sys("🔒 Read-only: Claude can see your screen, read files, and "
                          "answer — but won't edit anything or run commands.")

--- a/claude_overlay.py
+++ b/claude_overlay.py
@@ -81,6 +81,12 @@ class Overlay:
         self.auto_shot = AUTO_SCREENSHOT_DEFAULT
         self.window_shot = (SHOT_SCOPE == "window")   # True → capture only the active window
         self.share_visible = SHOW_IN_SCREEN_SHARE_DEFAULT   # True → overlay shows in screen shares
+        self.read_only = (PERMISSION_MODE == "plan")  # True → agent may look, not act; the toggle
+                                                      # flips it via the worker (confirmed async)
+        self._full_mode = (PERMISSION_MODE if PERMISSION_MODE != "plan"
+                           else "bypassPermissions")  # what Read-only OFF returns to: the
+                                                      # configured mode — unless that IS plan,
+                                                      # then the CLI default full-access mode
         self.pending_shot = None
         self.pending_images: list = []
         self._precaptured = None        # (shots, monotonic_ts) grabbed while typing
@@ -834,6 +840,10 @@ class Overlay:
         self.toggle_share.pack(side="left", padx=(self.px(8), self.px(2)), pady=pad)
         self.toggle_share.bind("<Button-1>", lambda e: self.toggle_screen_share())
         self._paint_share_toggle()
+        self.toggle_ro = tk.Label(st, bg=T["bg"], font=self.f_small, cursor="hand2")
+        self.toggle_ro.pack(side="left", padx=(self.px(8), self.px(2)), pady=pad)
+        self.toggle_ro.bind("<Button-1>", lambda e: self.toggle_read_only())
+        self._paint_ro_toggle()
         self._chip(st, "Compact", self.compact_now)
         self._chip(st, "Clear", self.reset)
         self.attach_lbl = tk.Label(st, text="", bg=T["bg"], fg=T["accent"],
@@ -1231,6 +1241,13 @@ class Overlay:
         on = self.share_visible
         self.toggle_share.configure(text=("◉  Shareable" if on else "○  Shareable"),
                                     fg=(T["accent"] if on else T["muted"]))
+
+    def _paint_ro_toggle(self):
+        # ON (◉, accent) = read-only ("plan"): Claude may look and answer, but not change
+        # anything; OFF (○, muted) = the configured full-access mode.
+        on = self.read_only
+        self.toggle_ro.configure(text=("◉  Read-only" if on else "○  Read-only"),
+                                 fg=(T["accent"] if on else T["muted"]))
 
     # ── rounded input layout ──
     def _layout_input(self, e=None):
@@ -2903,6 +2920,30 @@ class Overlay:
         else:
             self.add_sys("🖥 Screenshots capture all screens again (one image per monitor).")
 
+    def toggle_read_only(self):
+        """Ask the worker to flip between read-only ("plan") and the configured
+        full-access mode. Unlike the other toggles the state does NOT flip
+        optimistically: it only changes when the worker confirms the CLI accepted
+        the switch (the "permission_mode" event → _apply_permission_mode), so the
+        label never claims a safety state the agent isn't actually in."""
+        target = self._full_mode if self.read_only else "plan"
+        self._set_status("switching permissions…")
+        self.worker.set_permission_mode(target)
+
+    def _apply_permission_mode(self, mode):
+        """Worker confirmed the active permission mode: sync the toggle and, when it
+        actually changed, say so in-chat (the switch itself is invisible on screen)."""
+        ro = (mode == "plan")
+        changed = (ro != self.read_only)
+        self.read_only = ro
+        self._paint_ro_toggle()
+        if changed and ro:
+            self.add_sys("🔒 Read-only: Claude can see your screen, read files, and "
+                         "answer — but won't edit anything or run commands.")
+        elif changed:
+            self.add_sys(f"⚡ Full access ({mode}): Claude can now edit files and run "
+                         "commands without asking. Flip Read-only back on any time.")
+
     def toggle_screen_share(self):
         """Flip whether the overlay is visible in screen shares (Teams/Zoom/OBS). The change
         is invisible on your OWN screen — the window looks identical either way; it only
@@ -3379,6 +3420,8 @@ class Overlay:
                 self._precaptured = (payload, time.monotonic())
         elif kind == "status":
             self._set_status(str(payload))
+        elif kind == "permission_mode":
+            self._apply_permission_mode(str(payload))
         elif kind == "system":
             self.add_sys(str(payload))
         elif kind == "update":

--- a/claude_overlay.py
+++ b/claude_overlay.py
@@ -79,6 +79,7 @@ class Overlay:
         self.worker.start()
 
         self.auto_shot = AUTO_SCREENSHOT_DEFAULT
+        self.window_shot = (SHOT_SCOPE == "window")   # True → capture only the active window
         self.share_visible = SHOW_IN_SCREEN_SHARE_DEFAULT   # True → overlay shows in screen shares
         self.pending_shot = None
         self.pending_images: list = []
@@ -125,6 +126,10 @@ class Overlay:
         self._fronting = False            # re-entrancy guard for _raise_to_front (focus churn)
         self._vscreen_sig = None          # last virtual-desktop bounding box (display-topology sig)
         self._vscreen_checked = 0.0       # throttle the topology watchdog to ~1.5s in _poll
+        self._last_ext_fg = None          # last EXTERNAL foreground hwnd — the window the user was
+                                          # working in before focusing the overlay; the "window"
+                                          # capture scope targets it whenever the overlay has focus
+        self._fg_checked = 0.0            # throttle that tracking to ~0.5s in _poll
         # Per-overlay custom name (session-only, set by clicking the titlebar "Claude"). Shown
         # in the titlebar + window title when expanded, and as a small pill UNDER the orb when
         # collapsed — so several overlays open at once (one per task) are tellable apart at a
@@ -469,6 +474,12 @@ class Overlay:
         try:
             hwnd = self._hwnd()
             fg = _user32.GetForegroundWindow()
+            try:                              # the hotkey moment is the freshest possible
+                hw = foreground_capture_window()   # answer to "which window was the user in?"
+                if hw:                             # — record it before we steal the foreground
+                    self._last_ext_fg = hw
+            except Exception:
+                pass
             cur = _user32.GetWindowThreadProcessId(fg, None) if fg else 0
             me = _user32.GetWindowThreadProcessId(hwnd, None)
             attached = bool(cur and cur != me and _user32.AttachThreadInput(cur, me, True))
@@ -815,6 +826,10 @@ class Overlay:
         self.toggle_screen.pack(side="left", padx=(self.px(16), self.px(2)), pady=pad)
         self.toggle_screen.bind("<Button-1>", lambda e: self.toggle_auto())
         self._paint_screen_toggle()
+        self.toggle_window = tk.Label(st, bg=T["bg"], font=self.f_small, cursor="hand2")
+        self.toggle_window.pack(side="left", padx=(self.px(8), self.px(2)), pady=pad)
+        self.toggle_window.bind("<Button-1>", lambda e: self.toggle_window_shot())
+        self._paint_window_toggle()
         self.toggle_share = tk.Label(st, bg=T["bg"], font=self.f_small, cursor="hand2")
         self.toggle_share.pack(side="left", padx=(self.px(8), self.px(2)), pady=pad)
         self.toggle_share.bind("<Button-1>", lambda e: self.toggle_screen_share())
@@ -1203,6 +1218,12 @@ class Overlay:
     def _paint_screen_toggle(self):
         on = self.auto_shot
         self.toggle_screen.configure(text=("◉  Auto-shot" if on else "○  Auto-shot"),
+                                     fg=(T["accent"] if on else T["muted"]))
+
+    def _paint_window_toggle(self):
+        # ON (◉, accent) = screenshots capture only the active window; OFF = all screens.
+        on = self.window_shot
+        self.toggle_window.configure(text=("◉  Window-only" if on else "○  Window-only"),
                                      fg=(T["accent"] if on else T["muted"]))
 
     def _paint_share_toggle(self):
@@ -2619,7 +2640,11 @@ class Overlay:
         """Short text companion for inline-image turns: the model sees the images
         directly, so we only add a one-line note about what's attached."""
         note = []
-        if shots:
+        if shots and shots[0].get("window") is not None:
+            note.append(f"[Attached: a live screenshot of my ACTIVE WINDOW only — "
+                        f"“{shots[0]['window']}” — not the full screen; other "
+                        f"windows and monitors are not visible to you.]")
+        elif shots:
             tags = ", ".join(f"monitor {s['index']}" + (" (primary)" if s["primary"] else "")
                              for s in shots)
             note.append(f"[Attached: a live screenshot of my screen — {tags}.]")
@@ -2664,7 +2689,7 @@ class Overlay:
         shots = None
         try:
             mons = enumerate_monitors() or [{"rect": None, "primary": True}]
-            shots, _ = self._grab_shots(mons)
+            shots, _ = self._grab_shots_scoped(mons)
         except BaseException:
             shots = None
         finally:
@@ -2673,7 +2698,11 @@ class Overlay:
     def _build_prompt(self, text, shots, images=None):
         parts = []
         lines = []
-        if shots:
+        if shots and shots[0].get("window") is not None:
+            lines.append("My ACTIVE WINDOW was just captured — window only, NOT the full "
+                         "screen (other windows/monitors are not visible to you):")
+            lines.append(f"- Active window “{shots[0]['window']}”: {shots[0]['path']}")
+        elif shots:
             lines.append("My current display was just captured — one image per monitor:")
             for s in shots:
                 tag = "PRIMARY screen" if s["primary"] else "secondary screen"
@@ -2733,6 +2762,48 @@ class Overlay:
             pass
         return keep
 
+    def _capture_target_hwnd(self):
+        """The window a 'window'-scope capture should shoot: the current foreground
+        window when it's a usable external one, else the last external foreground
+        window _poll tracked (the app the user was in before focusing the overlay).
+        None → no usable window; the caller falls back to full-screen capture."""
+        hw = foreground_capture_window()
+        if hw:
+            return hw
+        hw = self._last_ext_fg
+        return hw if window_capturable(hw) else None
+
+    def _grab_window_shot(self):
+        """Capture ONLY the active window → ([shot], None), or (None, err) when there is
+        no usable window / the grab failed — the caller falls back to _grab_shots so a
+        capture is never silently dropped. Win32 + Pillow only, no Tk: safe on the
+        background precapture thread, like _grab_shots."""
+        try:
+            hwnd = self._capture_target_hwnd()
+            if not hwnd:
+                return None, None
+            bbox = window_bbox(hwnd)
+            if not bbox:
+                return None, None
+            img = ImageGrab.grab(bbox=bbox, all_screens=True)
+            if SHOT_MAX_EDGE and max(img.size) > SHOT_MAX_EDGE:
+                img.thumbnail((SHOT_MAX_EDGE, SHOT_MAX_EDGE), Image.LANCZOS)
+            p = self._save_shot(img, SHOT_DIR / f"shot_{int(time.time() * 1000)}_w")
+            self._prune_shots()
+            return [{"path": str(p), "primary": True, "index": 1,
+                     "window": window_title(hwnd) or "untitled window"}], None
+        except Exception as ex:
+            return None, ex
+
+    def _grab_shots_scoped(self, mons):
+        """Scope dispatcher used by both the send-time and precapture paths: the active
+        window when that scope is on AND a usable window exists, else every monitor."""
+        if self.window_shot:
+            shots, err = self._grab_window_shot()
+            if shots:
+                return shots, err
+        return self._grab_shots(mons)
+
     def _grab_shots(self, mons):
         """Pure capture: one screenshot per monitor → downscale → save. Touches NO Tk, so
         it is safe to run on a background thread (used by the precapture path). Returns
@@ -2774,7 +2845,7 @@ class Overlay:
             self.root.update()
             time.sleep(0.15)
         try:
-            shots, err = self._grab_shots(mons)
+            shots, err = self._grab_shots_scoped(mons)
         finally:
             if do_hide:
                 self.root.deiconify()
@@ -2819,6 +2890,18 @@ class Overlay:
     def toggle_auto(self):
         self.auto_shot = not self.auto_shot
         self._paint_screen_toggle()
+
+    def toggle_window_shot(self):
+        """Flip the capture scope between the active window and all screens. Like the
+        share toggle, the change is invisible on screen, so confirm it in-chat."""
+        self.window_shot = not self.window_shot
+        self._precaptured = None   # a frame grabbed under the OLD scope must not be sent
+        self._paint_window_toggle()
+        if self.window_shot:
+            self.add_sys("🎯 Screenshots now capture the ACTIVE WINDOW only "
+                         "(falls back to full screen when no window is in focus).")
+        else:
+            self.add_sys("🖥 Screenshots capture all screens again (one image per monitor).")
 
     def toggle_screen_share(self):
         """Flip whether the overlay is visible in screen shares (Teams/Zoom/OBS). The change
@@ -3156,6 +3239,19 @@ class Overlay:
                     if self._vscreen_sig is not None and sig != self._vscreen_sig:
                         self._ensure_on_screen()
                     self._vscreen_sig = sig
+            except Exception:
+                pass
+        # Track the most recent EXTERNAL foreground window (throttled, one cheap Win32
+        # call): when a "window"-scope capture happens while the overlay itself has
+        # focus — which is ALWAYS the case at send time, the user just typed here —
+        # this remembered hwnd is the window the user was actually working in. Tracked
+        # even while the toggle is off, so flipping it on works on the very next send.
+        if self._last_pump - self._fg_checked > 0.5:
+            self._fg_checked = self._last_pump
+            try:
+                hw = foreground_capture_window()
+                if hw:
+                    self._last_ext_fg = hw
             except Exception:
                 pass
         if DEBUG_LOG and (self._last_pump - getattr(self, "_pump_logged", 0.0)) > 10.0:

--- a/config.py
+++ b/config.py
@@ -132,6 +132,17 @@ SHOT_FORMAT = os.environ.get("CLAUDE_OVERLAY_SHOT_FORMAT", "auto").strip().lower
 SHOT_JPEG_QUALITY = _env_int("CLAUDE_OVERLAY_SHOT_JPEG_QUALITY", 82, 50, 95)
                                  # Claude downsamples larger images internally anyway, so
                                  # bigger files only cost upload time + vision tokens.
+SHOT_SCOPE = os.environ.get("CLAUDE_OVERLAY_SHOT_SCOPE", "screens").strip().lower()
+                                 # what a screenshot covers — the STARTUP default; flip it live
+                                 # via the status-bar "Window-only" toggle. "screens" (default):
+                                 # one image per monitor, Claude sees everything you see.
+                                 # "window": ONLY the active (foreground) window — more private
+                                 # and far cheaper in vision tokens, but Claude can't see other
+                                 # windows/monitors. When you're typing IN the overlay, "active"
+                                 # means the last window you worked in before it (tracked live);
+                                 # when no usable window exists (fresh launch, desktop focused,
+                                 # window minimized) it falls back to full-screen capture rather
+                                 # than sending nothing. Any other value → "screens".
 IMAGE_INPUT = "inline"           # "inline" → attach screenshots as base64 image blocks
                                  # (no per-turn Read round-trip); "read" → legacy path:
                                  # save PNG + ask Claude to Read it. Flip to "read" if a

--- a/config.py
+++ b/config.py
@@ -148,6 +148,16 @@ SHOT_SCOPE = os.environ.get("CLAUDE_OVERLAY_SHOT_SCOPE", "screens").strip().lowe
                                  # when no usable window exists (fresh launch, desktop focused,
                                  # window minimized) it falls back to full-screen capture rather
                                  # than sending nothing. Any other value → "screens".
+SHOT_SCOPE_FORCED = "CLAUDE_OVERLAY_SHOT_SCOPE" in os.environ
+                                 # an EXPLICIT env var is a per-launch decision, so it beats the
+                                 # remembered toggle state below; unset → last toggle choice wins
+STATE_FILE = Path(os.environ.get("LOCALAPPDATA") or Path.home()) / "claude-overlay" / "state.json"
+                                 # tiny per-machine store for UI-toggle state the user expects to
+                                 # survive a relaunch (currently: Window-only). Deliberately
+                                 # OUTSIDE the app folder: machine state must not dirty the git
+                                 # clone or ride along in updates. Permission mode is deliberately
+                                 # NOT persisted — starting locked/unlocked is a safety posture
+                                 # that should come from PERMISSION_MODE, not linger silently.
 IMAGE_INPUT = "inline"           # "inline" → attach screenshots as base64 image blocks
                                  # (no per-turn Read round-trip); "read" → legacy path:
                                  # save PNG + ask Claude to Read it. Flip to "read" if a

--- a/config.py
+++ b/config.py
@@ -153,11 +153,13 @@ SHOT_SCOPE_FORCED = "CLAUDE_OVERLAY_SHOT_SCOPE" in os.environ
                                  # remembered toggle state below; unset → last toggle choice wins
 STATE_FILE = Path(os.environ.get("LOCALAPPDATA") or Path.home()) / "claude-overlay" / "state.json"
                                  # tiny per-machine store for UI-toggle state the user expects to
-                                 # survive a relaunch (currently: Window-only). Deliberately
+                                 # survive a relaunch (Window-only and Read-only). Deliberately
                                  # OUTSIDE the app folder: machine state must not dirty the git
-                                 # clone or ride along in updates. Permission mode is deliberately
-                                 # NOT persisted — starting locked/unlocked is a safety posture
-                                 # that should come from PERMISSION_MODE, not linger silently.
+                                 # clone or ride along in updates. SHOT_SCOPE / PERMISSION_MODE
+                                 # seed the very first launch; after that the remembered toggle
+                                 # wins — and because a restored Read-only choice is a SAFETY
+                                 # state, the overlay announces it in-chat whenever it differs
+                                 # from the configured default.
 IMAGE_INPUT = "inline"           # "inline" → attach screenshots as base64 image blocks
                                  # (no per-turn Read round-trip); "read" → legacy path:
                                  # save PNG + ask Claude to Read it. Flip to "read" if a

--- a/config.py
+++ b/config.py
@@ -51,6 +51,11 @@ MODEL = "opus"   # startup default: the latest Opus family
 MODELS = [("Opus", "opus"), ("Opus (1M)", "opus[1m]"),
           ("Sonnet", "sonnet"), ("Haiku", "haiku")]  # click the statusline to switch
 PERMISSION_MODE = "bypassPermissions"
+                                 # the STARTUP permission mode; flip it at run time with the
+                                 # status-bar "Read-only" toggle (◉ = "plan", a read-only agent
+                                 # that can look and answer but not edit/run anything; ○ = back
+                                 # to this configured mode). "plan" here starts the overlay
+                                 # locked read-only. See the security note in README.md.
 # Tools the overlay must NEVER let the model call, because they need an interactive UI
 # this app can't provide. AskUserQuestion (Claude Code's structured multiple-choice
 # question tool) is the one that bites: when the model calls it, the CLI blocks waiting

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,6 +110,7 @@ def _clean_overlay(ov):
         pass
     # View / per-turn state reset() doesn't cover:
     ov.auto_shot = co.AUTO_SCREENSHOT_DEFAULT
+    ov.window_shot = (co.SHOT_SCOPE == "window")
     ov.share_visible = co.SHOW_IN_SCREEN_SHARE_DEFAULT
     ov.overlay_name = ""
     ov._model = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,7 @@ class FakeWorker:
     def reset(self):            self._rec("reset")
     def compact(self):          self._rec("compact")
     def set_model(self, *a):    self._rec("set_model", *a)
+    def set_permission_mode(self, *a):  self._rec("set_permission_mode", *a)
     def interrupt(self):        self._rec("interrupt")
     def shutdown(self):         self._rec("shutdown")
     def join(self, *a, **k):    self._rec("join")
@@ -112,6 +113,7 @@ def _clean_overlay(ov):
     ov.auto_shot = co.AUTO_SCREENSHOT_DEFAULT
     ov.window_shot = (co.SHOT_SCOPE == "window")
     ov.share_visible = co.SHOW_IN_SCREEN_SHARE_DEFAULT
+    ov.read_only = (co.PERMISSION_MODE == "plan")
     ov.overlay_name = ""
     ov._model = None
     ov._ctx_pct = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,11 @@ def _overlay_singleton():
     mp.setattr(co, "ClaudeWorker", FakeWorker)
     mp.setattr(co.Overlay, "_register_hotkey", lambda self: None)
     mp.setattr(co.Overlay, "_check_for_update", lambda self: None)
+    # Point the persisted-UI-state store at a throwaway path: the suite must neither
+    # read this machine's real toggle state nor overwrite it from toggle tests.
+    import tempfile
+    from pathlib import Path as _Path
+    mp.setattr(co, "STATE_FILE", _Path(tempfile.mkdtemp(prefix="ov_state_")) / "state.json")
     try:
         ov = co.Overlay()
     except Exception as e:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,10 +34,11 @@ class FakeWorker:
     """Stand-in for ClaudeWorker: stores the UI queue, records calls for assertions,
     starts no thread and connects to nothing."""
 
-    def __init__(self, ui_queue):
+    def __init__(self, ui_queue, permission_mode=None):
         self.ui = ui_queue
         self.req = queue.Queue()
         self.calls = []
+        self.permission_mode = permission_mode   # launch mode the Overlay asked for
 
     def _rec(self, name, *a):
         self.calls.append((name, a))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -239,3 +239,30 @@ class TestMiscConstants:
 
     def test_system_append_is_non_empty(self):
         assert len(config.SYSTEM_APPEND.strip()) > 0
+
+
+# ---------------------------------------------------------------------------
+# 7. SHOT_SCOPE
+# ---------------------------------------------------------------------------
+
+class TestShotScope:
+    """Tests for SHOT_SCOPE (active-window vs. all-screens capture default)."""
+
+    def test_default_is_screens(self):
+        env_val = os.environ.get("CLAUDE_OVERLAY_SHOT_SCOPE")
+        if env_val is not None:
+            pytest.skip("CLAUDE_OVERLAY_SHOT_SCOPE is set in env; skipping default check")
+        assert config.SHOT_SCOPE == "screens"
+
+    def test_env_override_is_normalized(self, monkeypatch):
+        # The env value is stripped + lowercased so "  Window " still means window scope.
+        monkeypatch.setenv("CLAUDE_OVERLAY_SHOT_SCOPE", "  Window ")
+        try:
+            importlib.reload(config)
+            assert config.SHOT_SCOPE == "window"
+        finally:
+            monkeypatch.delenv("CLAUDE_OVERLAY_SHOT_SCOPE", raising=False)
+            importlib.reload(config)
+
+    def test_shot_scope_is_str(self):
+        assert isinstance(config.SHOT_SCOPE, str)

--- a/tests/test_ui_compact_badge_share.py
+++ b/tests/test_ui_compact_badge_share.py
@@ -420,3 +420,35 @@ def test_apply_permission_mode_unchanged_mode_is_quiet(overlay):
     before = chat_text(overlay)
     overlay._apply_permission_mode(overlay._full_mode)
     assert chat_text(overlay) == before
+
+
+# ── Persisted UI state (window_shot survives a relaunch) ─────────────────────
+
+def test_save_and_load_state_roundtrip(monkeypatch, tmp_path):
+    import claude_overlay as co
+    monkeypatch.setattr(co, "STATE_FILE", tmp_path / "state.json")
+    co._save_state(window_shot=True)
+    assert co._load_state() == {"window_shot": True}
+    co._save_state(window_shot=False)        # merge/overwrite, not append
+    assert co._load_state() == {"window_shot": False}
+
+
+def test_load_state_corrupt_or_wrong_shape_is_empty(monkeypatch, tmp_path):
+    import claude_overlay as co
+    p = tmp_path / "state.json"
+    monkeypatch.setattr(co, "STATE_FILE", p)
+    p.write_text("{definitely not json", encoding="utf-8")
+    assert co._load_state() == {}
+    p.write_text('["a", "list"]', encoding="utf-8")   # valid JSON, wrong shape
+    assert co._load_state() == {}
+
+
+def test_toggle_window_shot_persists_choice(overlay, monkeypatch, tmp_path):
+    import claude_overlay as co
+    monkeypatch.setattr(co, "STATE_FILE", tmp_path / "state.json")
+    overlay.window_shot = False
+    overlay._paint_window_toggle()
+    overlay.toggle_window_shot()              # → on
+    assert co._load_state().get("window_shot") is True
+    overlay.toggle_window_shot()              # → off again
+    assert co._load_state().get("window_shot") is False

--- a/tests/test_ui_compact_badge_share.py
+++ b/tests/test_ui_compact_badge_share.py
@@ -382,3 +382,41 @@ def test_toggle_window_shot_drops_stale_precapture(overlay):
     overlay.toggle_window_shot()
     assert overlay._precaptured is None
     overlay.toggle_window_shot()  # restore
+
+
+# ── Read-only (permission mode) toggle ────────────────────────────────────────
+
+def test_toggle_read_only_asks_worker_does_not_flip_yet(overlay):
+    # Unlike the other toggles, state must NOT change until the worker confirms —
+    # the label must never claim a safety state the CLI isn't in.
+    before = overlay.read_only
+    overlay.toggle_read_only()
+    assert overlay.read_only == before
+    calls = [c for c in overlay.worker.calls if c[0] == "set_permission_mode"]
+    assert calls, "toggle must enqueue a set_permission_mode request"
+    target = calls[-1][1][0]
+    assert target == ("plan" if not before else overlay._full_mode)
+
+
+def test_apply_permission_mode_flips_paints_and_confirms(overlay):
+    overlay.read_only = False
+    overlay._paint_ro_toggle()
+    overlay._apply_permission_mode("plan")
+    overlay.root.update_idletasks()
+    assert overlay.read_only is True
+    txt = overlay.toggle_ro.cget("text")
+    assert "◉" in txt and "Read-only" in txt
+    assert "read-only" in chat_text(overlay).lower()
+    overlay._apply_permission_mode(overlay._full_mode)   # back to full access
+    assert overlay.read_only is False
+    assert "○" in overlay.toggle_ro.cget("text")
+
+
+def test_apply_permission_mode_unchanged_mode_is_quiet(overlay):
+    # Re-confirming the mode we're already in (e.g. after a failed switch re-sync)
+    # must not spam the chat.
+    overlay.read_only = False
+    overlay._paint_ro_toggle()
+    before = chat_text(overlay)
+    overlay._apply_permission_mode(overlay._full_mode)
+    assert chat_text(overlay) == before

--- a/tests/test_ui_compact_badge_share.py
+++ b/tests/test_ui_compact_badge_share.py
@@ -452,3 +452,47 @@ def test_toggle_window_shot_persists_choice(overlay, monkeypatch, tmp_path):
     assert co._load_state().get("window_shot") is True
     overlay.toggle_window_shot()              # → off again
     assert co._load_state().get("window_shot") is False
+
+
+# ── Read-only persistence (remembered across launches) ───────────────────────
+
+def test_startup_permission_mode_first_launch_follows_config(monkeypatch, tmp_path):
+    import claude_overlay as co
+    monkeypatch.setattr(co, "STATE_FILE", tmp_path / "absent.json")   # no saved state
+    monkeypatch.setattr(co, "PERMISSION_MODE", "plan")
+    assert co._startup_permission_mode() == (True, "plan")
+    monkeypatch.setattr(co, "PERMISSION_MODE", "bypassPermissions")
+    assert co._startup_permission_mode() == (False, "bypassPermissions")
+
+
+def test_startup_permission_mode_saved_choice_wins(monkeypatch, tmp_path):
+    import claude_overlay as co
+    monkeypatch.setattr(co, "STATE_FILE", tmp_path / "state.json")
+    # Remembered UNLOCK over a plan config: launch straight into full access — and
+    # into bypassPermissions specifically, so the session is born bypass-capable.
+    monkeypatch.setattr(co, "PERMISSION_MODE", "plan")
+    co._save_state(read_only=False)
+    assert co._startup_permission_mode() == (False, "bypassPermissions")
+    # Remembered LOCK over a bypass config: launch straight into plan.
+    monkeypatch.setattr(co, "PERMISSION_MODE", "bypassPermissions")
+    co._save_state(read_only=True)
+    assert co._startup_permission_mode() == (True, "plan")
+
+
+def test_startup_permission_mode_garbage_state_ignored(monkeypatch, tmp_path):
+    import claude_overlay as co
+    monkeypatch.setattr(co, "STATE_FILE", tmp_path / "state.json")
+    monkeypatch.setattr(co, "PERMISSION_MODE", "plan")
+    co._save_state(read_only="yes please")   # non-bool must fall back to the config default
+    assert co._startup_permission_mode() == (True, "plan")
+
+
+def test_apply_permission_mode_persists_confirmed_choice(overlay, monkeypatch, tmp_path):
+    import claude_overlay as co
+    monkeypatch.setattr(co, "STATE_FILE", tmp_path / "state.json")
+    overlay.read_only = False
+    overlay._paint_ro_toggle()
+    overlay._apply_permission_mode("plan")
+    assert co._load_state().get("read_only") is True
+    overlay._apply_permission_mode("acceptEdits")
+    assert co._load_state().get("read_only") is False

--- a/tests/test_ui_compact_badge_share.py
+++ b/tests/test_ui_compact_badge_share.py
@@ -346,3 +346,39 @@ def test_format_turn_error_returns_string(overlay):
     msg = overlay._format_turn_error(payload)
     assert isinstance(msg, str)
     assert len(msg) > 0
+
+
+# ── Window-only (active-window capture) toggle ────────────────────────────────
+
+def test_toggle_window_shot_flips_state(overlay):
+    before = overlay.window_shot
+    overlay.toggle_window_shot()
+    assert overlay.window_shot is not before
+    overlay.toggle_window_shot()  # restore
+
+
+def test_toggle_window_shot_label_reflects_state(overlay):
+    import claude_overlay as co
+    overlay.window_shot = (co.SHOT_SCOPE == "window")
+    overlay._paint_window_toggle()
+    overlay.toggle_window_shot()
+    overlay.root.update_idletasks()
+    txt = overlay.toggle_window.cget("text")
+    assert "Window-only" in txt
+    assert ("◉" in txt) if overlay.window_shot else ("○" in txt)
+    overlay.toggle_window_shot()  # restore
+
+
+def test_toggle_window_shot_adds_confirmation_line(overlay):
+    overlay.toggle_window_shot()
+    txt = chat_text(overlay).lower()
+    assert "window" in txt or "screen" in txt
+    overlay.toggle_window_shot()  # restore
+
+
+def test_toggle_window_shot_drops_stale_precapture(overlay):
+    # A frame grabbed under the OLD scope must not be sent after the scope changes.
+    overlay._precaptured = ([{"path": "x.png", "primary": True, "index": 1}], 0.0)
+    overlay.toggle_window_shot()
+    assert overlay._precaptured is None
+    overlay.toggle_window_shot()  # restore

--- a/tests/test_win32utils.py
+++ b/tests/test_win32utils.py
@@ -321,3 +321,71 @@ def test_set_window_icon_caches_handles_no_leak(monkeypatch):
     r2 = win32utils.set_window_icon(0x1)               # must reuse, not grow
     assert isinstance(r1, bool) and isinstance(r2, bool)   # never raised
     assert win32utils._icon_handle_cache == snapshot       # no new handles loaded
+
+
+# ── active-window capture helpers (SHOT_SCOPE="window") ─────────────────────────────
+
+# clamp_bbox is pure math (no Win32), so it gets exact assertions.
+
+def test_clamp_bbox_inside_virtual_screen_unchanged():
+    assert win32utils.clamp_bbox((100, 100, 900, 700), (0, 0, 1920, 1080)) == (100, 100, 900, 700)
+
+
+def test_clamp_bbox_clips_offscreen_overhang():
+    # Window dragged half off the left edge and past the bottom → only the visible part.
+    assert win32utils.clamp_bbox((-300, 900, 500, 1300), (0, 0, 1920, 1080)) == (0, 900, 500, 1080)
+
+
+def test_clamp_bbox_degenerate_overlap_is_none():
+    # Fully outside the virtual screen (e.g. stranded on an unplugged monitor) → nothing to grab.
+    assert win32utils.clamp_bbox((5000, 100, 5800, 700), (0, 0, 1920, 1080)) is None
+
+
+def test_clamp_bbox_sliver_is_none():
+    # A <8px visible sliver isn't worth sending as a "screenshot of the window".
+    assert win32utils.clamp_bbox((-795, 100, 5, 700), (0, 0, 1920, 1080)) is None
+
+
+def test_clamp_bbox_none_rect_is_none():
+    assert win32utils.clamp_bbox(None, (0, 0, 1920, 1080)) is None
+
+
+def test_clamp_bbox_without_vbox_passes_rect_through():
+    # virtual_screen_metrics() can return None (headless); the rect must survive unclipped.
+    assert win32utils.clamp_bbox((10, 10, 400, 300), None) == (10, 10, 400, 300)
+
+
+def test_clamp_bbox_negative_coords_legit_secondary():
+    # A monitor left of the primary means legitimate negative coords — must NOT be clipped
+    # when the virtual screen extends there.
+    assert win32utils.clamp_bbox((-1800, 50, -600, 900),
+                                 (-1920, 0, 3840, 1080)) == (-1800, 50, -600, 900)
+
+
+# The hwnd-taking helpers call the real Win32 API; assertions stay at the contract level
+# (type / no-raise), which holds even on a headless runner with no foreground window.
+
+def test_window_capturable_rejects_null_and_bogus():
+    assert win32utils.window_capturable(None) is False
+    assert win32utils.window_capturable(0) is False
+    assert win32utils.window_capturable(0xDEAD) is False   # not a real window
+
+
+def test_foreground_capture_window_never_raises():
+    hw = win32utils.foreground_capture_window()
+    assert hw is None or int(hw) != 0
+    if hw:
+        # Whatever it returned must be a live, visible, non-minimized, non-own window.
+        assert win32utils.window_capturable(hw)
+        assert win32utils.window_is_own(hw) is False
+
+
+def test_window_bbox_and_title_on_bogus_hwnd():
+    # Must degrade to None / "" rather than raise.
+    assert win32utils.window_bbox(0xDEAD) is None
+    assert win32utils.window_title(0xDEAD) == ""
+
+
+def test_window_is_own_unknown_defaults_true():
+    # "Can't tell" must fail SAFE (treated as our own window → never captured).
+    assert win32utils.window_is_own(None) is True

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -655,3 +655,24 @@ class TestBypassElevationFallback:
         events = _drain(w.ui)
         assert ("permission_mode", before) in events
         assert any(k == "error" for k, _ in events)
+
+
+# ---------------------------------------------------------------------------
+# 5e. Launch permission mode parameter
+# ---------------------------------------------------------------------------
+
+class TestLaunchPermissionMode:
+
+    def test_launch_mode_param_overrides_config(self):
+        w = ClaudeWorker(queue.Queue(), permission_mode="plan")
+        assert w._permission_mode == "plan"
+        assert w._bypass_capable is False     # plan launch → can never elevate to bypass
+
+    def test_launch_mode_bypass_is_capable(self):
+        w = ClaudeWorker(queue.Queue(), permission_mode="bypassPermissions")
+        assert w._permission_mode == "bypassPermissions"
+        assert w._bypass_capable is True
+
+    def test_launch_mode_default_follows_config(self):
+        w = make_worker()
+        assert w._permission_mode == config.PERMISSION_MODE

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -588,3 +588,70 @@ class TestEmitUsageModel:
         ctxs = [v for (k, v) in items if k == "ctx"]
         assert models == ["claude-opus-4-8[1m]"]
         assert ctxs == [12]
+
+
+# ---------------------------------------------------------------------------
+# 5d. bypassPermissions runtime-elevation fallback
+# ---------------------------------------------------------------------------
+
+class _FakeModeClient:
+    def __init__(self, fail=False):
+        self.calls, self.fail = [], fail
+
+    async def set_permission_mode(self, mode):
+        if self.fail:
+            raise RuntimeError("nope")
+        self.calls.append(mode)
+
+
+def _drain(q):
+    out = []
+    while True:
+        try:
+            out.append(q.get_nowait())
+        except queue.Empty:
+            return out
+
+
+class TestBypassElevationFallback:
+
+    def test_substitutes_accept_edits_when_not_launch_capable(self):
+        # A session NOT launched with --dangerously-skip-permissions can never be
+        # elevated to bypassPermissions (the CLI refuses) — the worker must switch to
+        # acceptEdits instead and confirm THAT mode to the UI, not the requested one.
+        w = make_worker()
+        w._bypass_capable = False
+        c = _FakeModeClient()
+        asyncio.run(w._do_set_permission_mode(c, "bypassPermissions"))
+        assert c.calls == ["acceptEdits"]
+        assert w._permission_mode == "acceptEdits"
+        assert ("permission_mode", "acceptEdits") in _drain(w.ui)
+
+    def test_passes_bypass_through_when_launch_capable(self):
+        w = make_worker()
+        w._bypass_capable = True
+        c = _FakeModeClient()
+        asyncio.run(w._do_set_permission_mode(c, "bypassPermissions"))
+        assert c.calls == ["bypassPermissions"]
+        assert w._permission_mode == "bypassPermissions"
+
+    def test_plan_never_substituted(self):
+        # The fallback must only affect ELEVATION to bypass — locking to plan is
+        # always allowed and must go through untouched.
+        w = make_worker()
+        w._bypass_capable = False
+        c = _FakeModeClient()
+        asyncio.run(w._do_set_permission_mode(c, "plan"))
+        assert c.calls == ["plan"]
+
+    def test_failure_keeps_mode_and_resyncs_ui(self):
+        # On a CLI refusal the active mode must NOT change, and the UI must get the
+        # UNCHANGED mode back so the toggle repaints truthfully (plus an error line).
+        w = make_worker()
+        w._bypass_capable = True
+        before = w._permission_mode
+        asyncio.run(w._do_set_permission_mode(_FakeModeClient(fail=True), "plan"))
+        assert w._permission_mode == before
+        events = _drain(w.ui)
+        assert ("permission_mode", before) in events
+        assert any(k == "error" for k, _ in events)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -360,11 +360,72 @@ class TestAllowTool:
             assert isinstance(result, PermissionResultAllow)
 
     def test_allows_ordinary_tool(self):
-        # Every non-blacklisted tool is still auto-approved (bypass-disabled hosts rely on this).
+        # Every non-blacklisted tool is still auto-approved (bypass-disabled hosts rely on
+        # this). Mode pinned explicitly: the callback's answer now depends on the ACTIVE
+        # permission mode, and the test must not float with the machine's config.
         w = make_worker()
+        w._permission_mode = "bypassPermissions"
         result = asyncio.run(w._allow_tool("Bash", {"command": "ls"}, None))
         from worker import PermissionResultAllow
         assert isinstance(result, PermissionResultAllow)
+
+    def test_plan_mode_denies_exit_plan_mode(self):
+        # THE read-only guarantee: in plan mode, ExitPlanMode (the tool that ASKS for
+        # write access) must be denied — the blanket auto-approve would otherwise grant
+        # it and silently lift read-only. Deny degrades to Allow only on an SDK too old
+        # to have PermissionResultDeny (where set_permission_mode doesn't exist either).
+        w = make_worker()
+        w._permission_mode = "plan"
+        if worker_module.PermissionResultDeny is None:
+            pytest.skip("SDK has no PermissionResultDeny; runtime mode switching is off too")
+        result = asyncio.run(w._allow_tool("ExitPlanMode", {}, None))
+        assert isinstance(result, worker_module.PermissionResultDeny)
+
+    def test_plan_mode_denies_any_escalation(self):
+        # Plan mode runs read-only tools without consulting the callback, so ANYTHING
+        # that reaches it is a request for more power — all of it must be denied.
+        w = make_worker()
+        w._permission_mode = "plan"
+        if worker_module.PermissionResultDeny is None:
+            pytest.skip("SDK has no PermissionResultDeny")
+        for tool in ("Bash", "Write", "Edit", "NotebookEdit"):
+            result = asyncio.run(w._allow_tool(tool, {}, None))
+            assert isinstance(result, worker_module.PermissionResultDeny), tool
+
+    def test_plan_mode_ask_user_question_keeps_specific_message(self):
+        # The AskUserQuestion deny (checked first) has its own message steering the model
+        # to ask inline; the read-only deny must not swallow it.
+        w = make_worker()
+        w._permission_mode = "plan"
+        if worker_module.PermissionResultDeny is None:
+            pytest.skip("SDK has no PermissionResultDeny")
+        result = asyncio.run(w._allow_tool("AskUserQuestion", {}, None))
+        assert "question" in (result.message or "").lower()
+
+
+# ---------------------------------------------------------------------------
+# 5c. Runtime permission-mode switching
+# ---------------------------------------------------------------------------
+
+class TestPermissionModeSwitch:
+
+    def test_enqueue_set_permission_mode(self):
+        w = make_worker()
+        w.set_permission_mode("plan")
+        kind, payload = w.req.get_nowait()
+        assert (kind, payload) == ("set_permission_mode", "plan")
+
+    def test_initial_mode_follows_config(self):
+        w = make_worker()
+        assert w._permission_mode == config.PERMISSION_MODE
+
+    def test_make_options_uses_runtime_mode_not_config(self):
+        # A reconnect after a runtime switch must come back in the SWITCHED mode: the
+        # options builder has to read the live attribute, not the startup constant.
+        w = make_worker()
+        w._permission_mode = "plan"
+        opts = w._make_options()
+        assert opts.permission_mode == "plan"
 
 
 # ---------------------------------------------------------------------------

--- a/win32utils.py
+++ b/win32utils.py
@@ -424,6 +424,134 @@ def virtual_screen_metrics():
         return None
 
 
+# ── active-window capture (SHOT_SCOPE="window") ────────────────────────────────
+# Everything needed to answer "which window is the user actually working in, and what
+# rectangle of the screen does it cover?" — used when screenshots are scoped to the
+# active window instead of every monitor.
+_user32.IsWindow.argtypes = [wt.HWND]
+_user32.IsWindow.restype = wt.BOOL
+_user32.IsWindowVisible.argtypes = [wt.HWND]
+_user32.IsWindowVisible.restype = wt.BOOL
+_user32.IsIconic.argtypes = [wt.HWND]
+_user32.IsIconic.restype = wt.BOOL
+_user32.GetWindowRect.argtypes = [wt.HWND, ctypes.c_void_p]
+_user32.GetWindowRect.restype = wt.BOOL
+_user32.GetWindowTextLengthW.argtypes = [wt.HWND]
+_user32.GetWindowTextLengthW.restype = ctypes.c_int
+_user32.GetWindowTextW.argtypes = [wt.HWND, ctypes.c_wchar_p, ctypes.c_int]
+_user32.GetWindowTextW.restype = ctypes.c_int
+_user32.GetShellWindow.restype = wt.HWND
+_user32.GetDesktopWindow.restype = wt.HWND
+_kernel32 = ctypes.windll.kernel32
+_kernel32.GetCurrentProcessId.restype = wt.DWORD
+GA_ROOT = 2
+# DWMWA_EXTENDED_FRAME_BOUNDS is the window's VISIBLE frame — unlike GetWindowRect it
+# excludes the drop shadow and the invisible resize borders, so the capture doesn't
+# include a strip of whatever sits behind the window. dwmapi guarded: it exists on
+# every supported Windows, but a load failure must degrade to GetWindowRect, not crash.
+DWMWA_EXTENDED_FRAME_BOUNDS = 9
+try:
+    _dwmapi = ctypes.windll.dwmapi
+    _dwmapi.DwmGetWindowAttribute.argtypes = [wt.HWND, wt.DWORD, ctypes.c_void_p, wt.DWORD]
+    _dwmapi.DwmGetWindowAttribute.restype = ctypes.c_long
+except Exception:
+    _dwmapi = None
+
+
+def window_is_own(hwnd):
+    """True when the window belongs to THIS process (the overlay itself — including the
+    collapsed orb): never a capture target, we want what the user is working in."""
+    try:
+        pid = wt.DWORD(0)
+        tid = _user32.GetWindowThreadProcessId(hwnd, ctypes.byref(pid)) if hwnd else 0
+        if not tid or not pid.value:
+            return True   # lookup failed → can't tell whose window this is
+        return pid.value == _kernel32.GetCurrentProcessId()
+    except Exception:
+        return True     # can't tell → treat as our own so it's never captured by mistake
+
+
+def window_capturable(hwnd):
+    """A window that still makes sense to screenshot: exists, visible, not minimized
+    (a minimized window's rect is a meaningless off-screen stub)."""
+    try:
+        return bool(hwnd and _user32.IsWindow(hwnd) and _user32.IsWindowVisible(hwnd)
+                    and not _user32.IsIconic(hwnd))
+    except Exception:
+        return False
+
+
+def foreground_capture_window():
+    """The top-level foreground window as a capture target, or None when the foreground
+    is unusable: this process (the user is typing in the overlay), the desktop/shell
+    (nothing focused), or a window that's gone/minimized. The caller falls back to the
+    last tracked external window, then to full-screen capture."""
+    try:
+        fg = _user32.GetForegroundWindow()
+        if not fg:
+            return None
+        fg = _user32.GetAncestor(fg, GA_ROOT) or fg
+        if fg in (_user32.GetShellWindow(), _user32.GetDesktopWindow()):
+            return None
+        if window_is_own(fg) or not window_capturable(fg):
+            return None
+        return fg
+    except Exception:
+        return None
+
+
+def window_title(hwnd):
+    """The window's title bar text ('' on failure) — labels the shot for the model."""
+    try:
+        n = _user32.GetWindowTextLengthW(hwnd)
+        if n <= 0:
+            return ""
+        buf = ctypes.create_unicode_buffer(n + 1)
+        _user32.GetWindowTextW(hwnd, buf, n + 1)
+        return buf.value
+    except Exception:
+        return ""
+
+
+def clamp_bbox(rect, vbox):
+    """Intersect a window rect (l,t,r,b) with the virtual-desktop box (x,y,w,h) so a
+    half-dragged-offscreen window grabs only its visible part; None when the visible
+    overlap is degenerate (<8px a side — nothing worth sending). Pure math, no Win32."""
+    if not rect:
+        return None
+    l, t, r, b = rect
+    if vbox:
+        x, y, w, h = vbox
+        l, t = max(l, x), max(t, y)
+        r, b = min(r, x + w), min(b, y + h)
+    if r - l < 8 or b - t < 8:
+        return None
+    return (l, t, r, b)
+
+
+def window_bbox(hwnd):
+    """Screen-space (l,t,r,b) of a window suitable for ImageGrab(all_screens=True):
+    DWM extended frame bounds (visible frame, no shadow) with GetWindowRect as the
+    fallback, clipped to the virtual desktop. None when it can't be determined."""
+    rect = None
+    if _dwmapi is not None:
+        rc = wt.RECT()
+        try:
+            if _dwmapi.DwmGetWindowAttribute(hwnd, DWMWA_EXTENDED_FRAME_BOUNDS,
+                                             ctypes.byref(rc), ctypes.sizeof(rc)) == 0:
+                rect = (rc.left, rc.top, rc.right, rc.bottom)
+        except Exception:
+            rect = None
+    if rect is None:
+        rc = wt.RECT()
+        try:
+            if _user32.GetWindowRect(hwnd, ctypes.byref(rc)):
+                rect = (rc.left, rc.top, rc.right, rc.bottom)
+        except Exception:
+            rect = None
+    return clamp_bbox(rect, virtual_screen_metrics())
+
+
 def _mon_rect(m):
     """The usable rectangle of a monitor dict: prefer the work area, fall back to the full rect."""
     return m.get("work") or m.get("rect")

--- a/worker.py
+++ b/worker.py
@@ -84,6 +84,12 @@ class ClaudeWorker(threading.Thread):
         # before the event loop starts; defaults to the raw alias so nothing breaks if
         # resolution is skipped or fails. See modelresolve for WHY (streaming alias lag).
         self._resolved_model = MODEL
+        # The ACTIVE permission mode. Starts at the config constant; the status-bar
+        # "Read-only" toggle switches it at run time ("plan" ⇄ the configured mode).
+        # Kept here (not just CLI-side) because (a) _make_options must rebuild any
+        # reconnect with the CURRENT mode, not the startup one, and (b) _allow_tool
+        # must know when it's read-only (see the plan guard there).
+        self._permission_mode = PERMISSION_MODE
 
     def ask(self, text: str, image_paths=None):
         self.req.put(("ask", (text, list(image_paths or []))))
@@ -132,6 +138,27 @@ class ClaudeWorker(threading.Thread):
         # line stuck on "switching model…".
         self.req.put(("set_model", model))
 
+    def set_permission_mode(self, mode):
+        # Queued like set_model, and for the same serialization reasons. The UI does NOT
+        # flip its toggle when it calls this — it waits for the ("permission_mode", mode)
+        # confirmation event, so the toggle never claims a safety state the CLI isn't in.
+        self.req.put(("set_permission_mode", mode))
+
+    async def _do_set_permission_mode(self, client, mode):
+        try:
+            fn = getattr(client, "set_permission_mode", None)
+            if fn is None:   # pre-0.1 SDKs: no runtime switching — keep the mode truthful
+                raise RuntimeError("this claude-agent-sdk can't switch permission modes "
+                                   "at run time — update it (pip install -U claude-agent-sdk)")
+            await fn(mode)
+            self._permission_mode = mode   # AFTER success only; also survives reconnects
+            self.ui.put(("permission_mode", mode))
+        except Exception as e:
+            self.ui.put(("error", f"permission switch failed: {type(e).__name__}: {e}"))
+            self.ui.put(("permission_mode", self._permission_mode))   # re-sync the toggle
+        finally:
+            self.ui.put(("status", ""))
+
     async def _do_set_model(self, client, model):
         try:
             # Switching also goes through the streaming transport, which lags the alias the
@@ -167,6 +194,18 @@ class ClaudeWorker(threading.Thread):
             return PermissionResultDeny(
                 message="This overlay has no interactive question UI. Ask the user your "
                         "question inline as plain text and wait for their typed reply.")
+        # Read-only guard: while the active mode is "plan", DENY everything this callback
+        # is consulted about. Plan mode lets read-only tools run without asking, so any
+        # call that reaches here is a request for MORE power — including ExitPlanMode,
+        # the tool plan mode uses to ask for write access. The blanket auto-approve
+        # below would grant that and silently lift read-only out from under the user;
+        # denying keeps the "Read-only" toggle honest until the user flips it off.
+        if self._permission_mode == "plan" and PermissionResultDeny is not None:
+            return PermissionResultDeny(
+                message="The user has locked this overlay READ-ONLY (plan mode). Don't "
+                        "retry the call or try to exit plan mode — present your findings "
+                        "as text, and mention that the user can flip the Read-only "
+                        "status-bar toggle off if they want you to make the change.")
         # Auto-approve every other tool. permission_mode="bypassPermissions" already does
         # this on most machines, but managed/enterprise installs can DISABLE bypass
         # mode (managed-settings.json: disableBypassPermissionsMode), which makes the
@@ -179,7 +218,7 @@ class ClaudeWorker(threading.Thread):
 
     def _make_options(self) -> ClaudeAgentOptions:
         opts = dict(
-            permission_mode=PERMISSION_MODE, cwd=WORKING_DIR, model=self._resolved_model,
+            permission_mode=self._permission_mode, cwd=WORKING_DIR, model=self._resolved_model,
             can_use_tool=self._allow_tool,
             include_partial_messages=True,
             # exclude_dynamic_sections strips the per-turn-changing bits (cwd, git
@@ -300,6 +339,12 @@ class ClaudeWorker(threading.Thread):
                         self.ui.put(("status", ""))
                     else:
                         await self._do_set_model(self._client, payload)
+                elif kind == "set_permission_mode":
+                    if self._client is None:
+                        self.ui.put(("error", "Not connected to Claude yet — can't switch permissions."))
+                        self.ui.put(("status", ""))
+                    else:
+                        await self._do_set_permission_mode(self._client, payload)
             except asyncio.CancelledError:
                 # a cancel (Stop / transport teardown) must not break the loop or be
                 # mistaken for a fatal error — CancelledError is BaseException, not

--- a/worker.py
+++ b/worker.py
@@ -69,7 +69,7 @@ from debuglog import dbg, DEBUG_LOG, _UIQueueTap, _dbg_stream_last, _dbg_think_l
 from modelresolve import resolve_model
 
 class ClaudeWorker(threading.Thread):
-    def __init__(self, ui_queue: "queue.Queue"):
+    def __init__(self, ui_queue: "queue.Queue", permission_mode=None):
         super().__init__(daemon=True)
         # Tap the UI channel so the debug log captures every worker→UI event (no-op when
         # DEBUG_LOG is ""). The UI side keeps reading the raw queue.
@@ -84,18 +84,19 @@ class ClaudeWorker(threading.Thread):
         # before the event loop starts; defaults to the raw alias so nothing breaks if
         # resolution is skipped or fails. See modelresolve for WHY (streaming alias lag).
         self._resolved_model = MODEL
-        # The ACTIVE permission mode. Starts at the config constant; the status-bar
-        # "Read-only" toggle switches it at run time ("plan" ⇄ the configured mode).
+        # The ACTIVE permission mode. Starts at the caller's launch mode (the UI passes
+        # the remembered Read-only state; None → the config constant); the status-bar
+        # "Read-only" toggle switches it at run time ("plan" ⇄ the full-access mode).
         # Kept here (not just CLI-side) because (a) _make_options must rebuild any
         # reconnect with the CURRENT mode, not the startup one, and (b) _allow_tool
         # must know when it's read-only (see the plan guard there).
-        self._permission_mode = PERMISSION_MODE
+        self._permission_mode = permission_mode or PERMISSION_MODE
         # Whether THIS session may ever be switched to bypassPermissions at run time:
         # the CLI refuses to ELEVATE a running session to bypass unless it was launched
         # with --dangerously-skip-permissions, and the SDK only adds that flag when the
         # session STARTS in bypass mode. Re-derived on every _open() (a reconnect that
         # happens while read-only relaunches without the flag).
-        self._bypass_capable = (PERMISSION_MODE == "bypassPermissions")
+        self._bypass_capable = (self._permission_mode == "bypassPermissions")
 
     def ask(self, text: str, image_paths=None):
         self.req.put(("ask", (text, list(image_paths or []))))

--- a/worker.py
+++ b/worker.py
@@ -90,6 +90,12 @@ class ClaudeWorker(threading.Thread):
         # reconnect with the CURRENT mode, not the startup one, and (b) _allow_tool
         # must know when it's read-only (see the plan guard there).
         self._permission_mode = PERMISSION_MODE
+        # Whether THIS session may ever be switched to bypassPermissions at run time:
+        # the CLI refuses to ELEVATE a running session to bypass unless it was launched
+        # with --dangerously-skip-permissions, and the SDK only adds that flag when the
+        # session STARTS in bypass mode. Re-derived on every _open() (a reconnect that
+        # happens while read-only relaunches without the flag).
+        self._bypass_capable = (PERMISSION_MODE == "bypassPermissions")
 
     def ask(self, text: str, image_paths=None):
         self.req.put(("ask", (text, list(image_paths or []))))
@@ -145,6 +151,13 @@ class ClaudeWorker(threading.Thread):
         self.req.put(("set_permission_mode", mode))
 
     async def _do_set_permission_mode(self, client, mode):
+        if mode == "bypassPermissions" and not self._bypass_capable:
+            # This session can't be elevated to bypass (see _bypass_capable). acceptEdits
+            # is the runtime-reachable full-access equivalent HERE: anything else that
+            # would prompt is auto-approved by _allow_tool once we're out of plan mode,
+            # so the only practical difference is the label. The substituted mode is what
+            # gets confirmed to the UI, so the in-chat notice reflects reality.
+            mode = "acceptEdits"
         try:
             fn = getattr(client, "set_permission_mode", None)
             if fn is None:   # pre-0.1 SDKs: no runtime switching — keep the mode truthful
@@ -371,6 +384,7 @@ class ClaudeWorker(threading.Thread):
     async def _open(self):
         try:
             self._client = ClaudeSDKClient(options=self._make_options())
+            self._bypass_capable = (self._permission_mode == "bypassPermissions")
             # Bound the connect: a wedged transport (TLS MITM, half-open socket, CLI stuck on
             # a prompt) would otherwise hang the worker here forever, where no reconnect/restart
             # guard can reach it. A timeout degrades to the normal "couldn't start" path.


### PR DESCRIPTION
## What

Two new status-bar toggles, both born from using the overlay on multi-monitor setups and around sensitive content:

- **◉ / ○ Window-only** — screenshots capture **only the active window** instead of one image per monitor. Startup default via `SHOT_SCOPE` / `CLAUDE_OVERLAY_SHOT_SCOPE` (same pattern as `SHOT_FORMAT`); default remains `"screens"`, so behavior is unchanged unless opted in.
- **◉ / ○ Read-only** — switches the live session between `"plan"` (Claude can see the screen, read files, and answer — but not edit or run anything) and the configured full-access mode, without a restart. `PERMISSION_MODE` becomes the first-launch default.

Both remember the user's last choice across launches in a tiny per-machine state file (`%LOCALAPPDATA%\claude-overlay\state.json` — outside the app folder so machine state never dirties a git clone or rides along in updates).

## Why

- **Privacy**: on a call, or with mail/chat open on the second monitor, you often want Claude to see the document you're asking about — and nothing else. Window-only also cuts vision-token cost and upload time to a fraction on multi-monitor setups.
- **Safety**: the README already recommends `"plan"` for cautious users, but as a constant it forced an all-or-nothing choice at startup. A live toggle gives a trust dial: start locked, unlock when you want the agent to act, lock it back.

## How — Window-only capture

- The interesting problem: at send time the *overlay* is always the foreground window (the user just typed in it). The UI pump therefore tracks the most recent **external** foreground window on the existing throttled path (one extra Win32 call every 0.5 s), and the hotkey path records it at the summon moment; a window-scope capture shoots the current foreground window when it's a usable external one, else that tracked window.
- The rectangle comes from `DwmGetWindowAttribute(DWMWA_EXTENDED_FRAME_BOUNDS)` — the visible frame, no drop shadow / invisible resize borders — with `GetWindowRect` fallback, clipped to the virtual desktop (pure helper `clamp_bbox`, unit-tested).
- The attachment note tells the model it is seeing ONE window (with its title), not the full screen, in both the inline-image and legacy `[ATTACHMENTS]` paths.
- **Fallback**: no usable target (fresh launch, desktop focused, window minimized, DWM failure) → normal all-screens capture, never a silently dropped shot. Toggling scope drops any precaptured frame from the old scope.

## How — Read-only toggle

- Runtime switching uses the SDK's `set_permission_mode`, serialized through the worker's request queue like model switching. The toggle is **pessimistic**: it only flips once the CLI confirms, so it never claims a safety state the session isn't in. The active mode survives the worker's automatic reconnects (`_make_options` reads the live mode).
- **The critical companion guard**: this overlay auto-approves every permission prompt (a no-TTY GUI has nowhere to show one), which in plan mode would auto-approve `ExitPlanMode` — the tool plan mode uses to *ask* for write access — silently lifting read-only. While the active mode is plan, `_allow_tool` now **denies** every escalation it is consulted about, with a message steering the model to answer in text and point the user at the toggle.
- The CLI refuses to elevate a running session to `bypassPermissions` unless it was *launched* with `--dangerously-skip-permissions`, so unlocking a plan-launched session lands on `acceptEdits` instead — effectively full access here (everything that would prompt is auto-approved outside plan), and the confirmed mode is what the toggle and in-chat notice display. A *remembered* unlock avoids the fallback entirely by launching the next session directly in the full-access mode.
- Because a remembered Read-only choice is a safety state, startup announces it in-chat whenever it differs from the configured default — a launch never comes up unlocked as a silent surprise.

## Screen-capture & permission behavior callout (per CONTRIBUTING)

Both changes move in the *restricting* direction:

- Window-only capture shows the model strictly **less** of the screen; own-process windows are never a target, and "can't tell whose window this is" fails safe to *not* capturing.
- Read-only is a user-visible lock the model cannot exit; on failure to switch, the worker re-syncs the toggle to the mode the session is actually in.
- Defaults are unchanged (`"screens"`, `"bypassPermissions"`).

## Tests

44 new tests across `test_win32utils.py` (pure `clamp_bbox` exact tests; contract-level, headless-tolerant hwnd helper tests), `test_config.py` (`SHOT_SCOPE` default + env normalization), `test_worker.py` (plan-mode deny guard, elevation fallback incl. failure re-sync, launch-mode parameter), and `test_ui_compact_badge_share.py` (toggle behavior, state persistence round-trips, corrupt-state handling). Full suite: 328 passed. No new dependencies (Win32 via ctypes + existing Pillow).

Happy to split this into two PRs (window capture / read-only) if you prefer — the read-only commits build on the state store introduced in the window-capture ones, so they're stacked here in five commits that review independently in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
