### PR TITLE
Per-machine config.json: personalize the overlay without editing config.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to Claude Overlay are documented here.
 This project follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- **Personal settings now live in a per-machine `config.json` — no more editing
+  `config.py`.** Drop the settings you want to change (e.g. `{"PERMISSION_MODE":
+  "plan", "THEME": "dark"}`) into `%LOCALAPPDATA%\claude-overlay\config.json` (or any
+  path via the `CLAUDE_OVERLAY_CONFIG` env var) and they override the committed
+  defaults at startup — so a customized setup survives every `git pull` / `update.cmd`
+  with no conflicts. Precedence: constants < `config.json` < an explicitly set
+  `CLAUDE_OVERLAY_*` env var, and the remembered ⚙-toggle state still wins over all
+  three, exactly as before. Values are validated against a whitelist; anything typo'd,
+  wrong-typed, or unknown is skipped and called out in-chat at startup — a mistake in
+  the file can never silently launch a misconfigured (say, full-access) session, and a
+  broken file degrades to the defaults instead of preventing launch. See the README's
+  **Configuration** section for the full list of overridable settings.
+
 ## [1.12.1] — 2026-07-16
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -292,7 +292,40 @@ Double-click **`Create Desktop Shortcut.cmd`** to drop a **Claude Overlay** shor
 
 ## Configuration
 
-All settings are constants at the top of `claude_overlay.py`:
+All settings live as constants at the top of `config.py` — but **you don't have to edit
+the file**. Put personal values in a small per-machine **`config.json`** instead, so your
+setup survives every update with no `git pull` conflicts:
+
+```
+%LOCALAPPDATA%\claude-overlay\config.json
+```
+
+(the same folder that already remembers your toggles). List only the settings you want
+to change, using the constant names below — for example:
+
+```json
+{
+  "PERMISSION_MODE": "plan",
+  "THEME": "dark",
+  "WORKING_DIR": "C:\\Users\\you\\Documents"
+}
+```
+
+Overridable: `WORKING_DIR`, `MODEL`, `PERMISSION_MODE`, `SKILLS`, `STRICT_MCP_CONFIG`,
+`CLI_UPDATE_CHECK`, `AUTO_SCREENSHOT_DEFAULT`, `SHOT_SCOPE`, `SHOT_FORMAT`,
+`SHOT_JPEG_QUALITY`, `HIDE_SCREENSHOT_TOOL`, `THEME`, `SHOW_IN_SCREEN_SHARE_DEFAULT`,
+`TASKBAR_BUTTON`, `HOTKEY`, `WINDOW_ALPHA`, `CORNER_RADIUS`, `ORB_SIZE`,
+`FONT_SANS` / `FONT_SERIF` / `FONT_MONO`.
+
+Precedence, weakest to strongest: the constants in `config.py` < `config.json` < an
+explicitly set `CLAUDE_OVERLAY_*` env var — and the remembered ⚙-toggle state
+(Window-only / Read-only) still wins over all three, exactly as it does over the
+constants: `SHOT_SCOPE` and `PERMISSION_MODE` from the file only seed the first launch.
+A typo'd key or wrong-typed value is skipped (never fatal) and called out in-chat at
+startup, so a mistake can't silently launch a misconfigured session. To keep the file
+somewhere else, point the `CLAUDE_OVERLAY_CONFIG` env var at it.
+
+The settings themselves:
 
 - `MODEL` — defaults to `"opus"`, a **family alias for the latest Opus**, so a future
   Opus release is adopted automatically. Use `"opus[1m]"` for the 1M-context variant, or

--- a/claude_overlay.py
+++ b/claude_overlay.py
@@ -280,6 +280,11 @@ class Overlay:
                          "Read-only toggle off for full access." if self.read_only else
                          "⚡ Full access restored from your last session (you had "
                          "switched Read-only off). Flip it back on any time.")
+        # Anything the per-machine config.json couldn't apply (typo'd key, wrong type,
+        # unreadable file) must be SEEN — a silently-skipped PERMISSION_MODE would
+        # launch a full-access session the user believed was read-only.
+        for w in USER_CONFIG_WARNINGS:
+            self.add_sys(f"⚠ {USER_CONFIG_FILE.name}: {w}")
 
         self.root.after(130, lambda: (self.root.focus_force(), self.entry.focus_set()))
         self.root.bind("<Configure>", self._on_configure)

--- a/config.py
+++ b/config.py
@@ -3,6 +3,7 @@
 Claude Overlay. Pure data + small env helpers; no project imports (leaf module),
 so anything may import it without a circular-import risk."""
 
+import json
 import os
 from pathlib import Path
 
@@ -253,4 +254,156 @@ THEMES = {
         "sel": "#3A3934", "hover": "#30302E",
     },
 }
+
+# ── per-machine overrides: config.json ──────────────────────────────────────
+# Every constant above is a COMMITTED default — editing this file to taste dirties the
+# git clone and turns every `git pull` into a conflict (or forces a rebase dance). So
+# personal settings go in a tiny JSON file OUTSIDE the repo instead, in the same
+# per-machine home that already holds the toggle state (STATE_FILE):
+#
+#     %LOCALAPPDATA%\claude-overlay\config.json
+#     e.g.  { "PERMISSION_MODE": "plan", "THEME": "dark" }
+#
+# (or set CLAUDE_OVERLAY_CONFIG to any path — also how the tests isolate themselves).
+# Precedence, weakest → strongest: the constants above < config.json < an explicitly
+# set CLAUDE_OVERLAY_* env var (a per-launch decision keeps its old rank). And exactly
+# like the constants they replace, SHOT_SCOPE / PERMISSION_MODE from the file only SEED
+# the very first launch — the remembered Window-only / Read-only toggle state still wins.
+# Unknown keys and wrong-typed values are SKIPPED, never fatal: each problem lands in
+# USER_CONFIG_WARNINGS and the overlay surfaces them in-chat at startup, so a typo can't
+# silently launch a misconfigured (say, full-access) session.
+USER_CONFIG_FILE = Path(os.environ.get("CLAUDE_OVERLAY_CONFIG")
+                        or Path(os.environ.get("LOCALAPPDATA") or Path.home())
+                        / "claude-overlay" / "config.json")
+USER_CONFIG_WARNINGS: list = []   # human-readable; shown in-chat by the overlay at startup
+
+_BAD = object()   # sentinel: a validator rejected the value
+
+
+def _v_bool(v):
+    return v if isinstance(v, bool) else _BAD   # JSON true/false only — "true" is a typo
+
+
+def _v_str(v):
+    return v if isinstance(v, str) and v.strip() else _BAD
+
+
+def _v_choice(*allowed):
+    """Case-insensitive membership, returning the CANONICAL spelling (the CLI wants
+    "bypassPermissions", not whatever casing the user typed)."""
+    def check(v):
+        if isinstance(v, str):
+            s = v.strip().lower()
+            for a in allowed:
+                if s == a.lower():
+                    return a
+        return _BAD
+    return check
+
+
+def _v_num(lo, hi, cast):
+    """Clamp into [lo, hi] like _env_int does — a slightly-out-of-range number means
+    'as far as it goes', not a typo worth rejecting. bool is an int; exclude it."""
+    def check(v):
+        if isinstance(v, (int, float)) and not isinstance(v, bool):
+            return cast(max(lo, min(hi, v)))
+        return _BAD
+    return check
+
+
+def _v_str_list(v):
+    if isinstance(v, list) and v and all(isinstance(s, str) and s.strip() for s in v):
+        return list(v)
+    return _BAD
+
+
+def _v_skills(v):
+    return v if v is None or v == "all" else _v_str_list(v)
+
+
+def _v_dir(v):
+    """WORKING_DIR: expand ~ and %VARS%, and require the directory to EXIST — the CLI
+    is spawned with this as its cwd, and a bad cwd fails far less legibly than this."""
+    if not (isinstance(v, str) and v.strip()):
+        return _BAD
+    p = os.path.expandvars(os.path.expanduser(v.strip()))
+    return p if os.path.isdir(p) else _BAD
+
+
+# Which constants config.json may override, and how each value is checked. Deliberately
+# a whitelist: derived/structural values (STATE_FILE, SHOT_DIR, THEMES, MODELS, the
+# MAX_* safety caps…) stay source-only.
+_USER_CONFIG_KEYS = {
+    # agent
+    "WORKING_DIR": _v_dir,
+    "MODEL": _v_str,
+    "PERMISSION_MODE": _v_choice("bypassPermissions", "acceptEdits", "default", "plan"),
+    "SKILLS": _v_skills,                       # "all" | ["name", …] | null
+    "STRICT_MCP_CONFIG": _v_bool,
+    "CLI_UPDATE_CHECK": _v_bool,
+    # capture
+    "AUTO_SCREENSHOT_DEFAULT": _v_bool,
+    "SHOT_SCOPE": _v_choice("screens", "window"),
+    "SHOT_FORMAT": _v_choice("auto", "png", "jpeg"),
+    "SHOT_JPEG_QUALITY": _v_num(50, 95, int),
+    "HIDE_SCREENSHOT_TOOL": _v_bool,
+    # appearance / window
+    "THEME": _v_choice("light", "dark"),
+    "SHOW_IN_SCREEN_SHARE_DEFAULT": _v_bool,
+    "TASKBAR_BUTTON": _v_bool,
+    "HOTKEY": _v_str,
+    "WINDOW_ALPHA": _v_num(0.3, 1.0, float),   # floor 0.3: an ~invisible window looks broken
+    "CORNER_RADIUS": _v_num(0, 40, int),
+    "ORB_SIZE": _v_num(24, 160, int),
+    "FONT_SANS": _v_str_list,
+    "FONT_SERIF": _v_str_list,
+    "FONT_MONO": _v_str_list,
+}
+
+# Settings that ALSO have an env var: an explicitly set (non-blank) env var is a
+# per-launch decision and beats the file — the same rank env overrides always had.
+_ENV_BEATS_JSON = {
+    "SHOT_FORMAT": "CLAUDE_OVERLAY_SHOT_FORMAT",
+    "SHOT_JPEG_QUALITY": "CLAUDE_OVERLAY_SHOT_JPEG_QUALITY",
+    "SHOT_SCOPE": "CLAUDE_OVERLAY_SHOT_SCOPE",
+    "STRICT_MCP_CONFIG": "CLAUDE_OVERLAY_STRICT_MCP",
+    "CLI_UPDATE_CHECK": "CLAUDE_OVERLAY_CLI_UPDATE_CHECK",
+}
+
+
+def _apply_user_config():
+    """Overlay USER_CONFIG_FILE onto the module constants, collecting a warning for
+    everything skipped. Never raises: a broken config file must degrade to the
+    committed defaults, not kill the app at import time."""
+    try:
+        if not USER_CONFIG_FILE.is_file():
+            return
+        if USER_CONFIG_FILE.stat().st_size > 64 * 1024:   # sanity cap, like STATE_FILE
+            USER_CONFIG_WARNINGS.append("file is implausibly large — ignored.")
+            return
+        data = json.loads(USER_CONFIG_FILE.read_text("utf-8"))
+        if not isinstance(data, dict):
+            USER_CONFIG_WARNINGS.append("top level must be a JSON object — ignored.")
+            return
+    except Exception as e:
+        USER_CONFIG_WARNINGS.append(f"couldn't read it ({e}) — using the defaults.")
+        return
+    for key, val in data.items():
+        check = _USER_CONFIG_KEYS.get(key)
+        if check is None:
+            USER_CONFIG_WARNINGS.append(f"unknown setting {key!r} — ignored.")
+            continue
+        env = _ENV_BEATS_JSON.get(key)
+        if env and (os.environ.get(env) or "").strip():
+            continue                       # explicit env var outranks the file this launch
+        good = check(val)
+        if good is _BAD:
+            USER_CONFIG_WARNINGS.append(
+                f"invalid value for {key}: {val!r} — keeping the default.")
+            continue
+        globals()[key] = good
+
+
+_apply_user_config()
+
 T = THEMES.get(THEME, THEMES["light"])

--- a/config.py
+++ b/config.py
@@ -371,6 +371,16 @@ _ENV_BEATS_JSON = {
 }
 
 
+def _perm_note(key):
+    """When a skipped key is PERMISSION_MODE, spell out the mode still in force — the
+    committed default is bypassPermissions (full access), so a typo'd read-only intent
+    would otherwise fall through to a permissive session with only a generic warning."""
+    if key != "PERMISSION_MODE":
+        return ""
+    mode = globals().get("PERMISSION_MODE")
+    return f" — running in {mode!r}{', full access' if mode == 'bypassPermissions' else ''}"
+
+
 def _apply_user_config():
     """Overlay USER_CONFIG_FILE onto the module constants, collecting a warning for
     everything skipped. Never raises: a broken config file must degrade to the
@@ -381,7 +391,11 @@ def _apply_user_config():
         if USER_CONFIG_FILE.stat().st_size > 64 * 1024:   # sanity cap, like STATE_FILE
             USER_CONFIG_WARNINGS.append("file is implausibly large — ignored.")
             return
-        data = json.loads(USER_CONFIG_FILE.read_text("utf-8"))
+        # utf-8-sig, not utf-8: Notepad and PowerShell Out-File/Set-Content default to a
+        # UTF-8 BOM on Windows; plain "utf-8" leaves it in the text, json.loads then raises
+        # and the WHOLE file is discarded — silently reverting PERMISSION_MODE to the
+        # bypassPermissions default. "utf-8-sig" strips the BOM if present, no-op without.
+        data = json.loads(USER_CONFIG_FILE.read_text("utf-8-sig"))
         if not isinstance(data, dict):
             USER_CONFIG_WARNINGS.append("top level must be a JSON object — ignored.")
             return
@@ -396,10 +410,17 @@ def _apply_user_config():
         env = _ENV_BEATS_JSON.get(key)
         if env and (os.environ.get(env) or "").strip():
             continue                       # explicit env var outranks the file this launch
-        good = check(val)
+        try:
+            good = check(val)
+        except Exception:
+            # A validator that touches the OS (e.g. _v_dir → os.path.isdir) can raise on a
+            # hostile value — on Windows a null byte gives "ValueError: embedded null byte".
+            # Must degrade to a warning here: this loop runs at import, so a propagating
+            # exception would break `from config import *` and the app wouldn't launch.
+            good = _BAD
         if good is _BAD:
             USER_CONFIG_WARNINGS.append(
-                f"invalid value for {key}: {val!r} — keeping the default.")
+                f"invalid value for {key}: {val!r} — keeping the default{_perm_note(key)}.")
             continue
         globals()[key] = good
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,8 +15,16 @@ shown: no flash, no focus steal). Skips cleanly if Tk has no display.
 import os
 import queue
 import sys
+import tempfile
 
 import pytest
+
+# Isolate the whole suite from THIS machine's personal config.json overrides: the unit
+# tests assert the COMMITTED defaults, and the UI suite must not inherit a personal
+# theme/permission mode. Point the override loader at a path that can't exist — set
+# BEFORE the first `import config` anywhere (conftest imports before test modules).
+os.environ["CLAUDE_OVERLAY_CONFIG"] = os.path.join(
+    tempfile.gettempdir(), "claude_overlay_test_no_user_config", "config.json")
 
 # Belt-and-suspenders for the one Tk init (and any stray second root): pin the Tcl/Tk
 # library dirs so the interpreter always finds them.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -382,3 +382,40 @@ class TestUserConfig:
         assert load_cfg({"SKILLS": None}).SKILLS is None
         c = load_cfg({"SKILLS": 42})
         assert any("SKILLS" in w for w in c.USER_CONFIG_WARNINGS)
+
+    def test_structural_globals_are_not_overridable(self, load_cfg):
+        # The whitelist is a security boundary: derived/structural globals must stay
+        # source-only. Trying to set them from the file leaves them untouched and is
+        # reported as an unknown setting, not silently applied.
+        before_state = config.STATE_FILE
+        before_max = config.MAX_BUFFER_SIZE
+        c = load_cfg({"STATE_FILE": r"C:\evil\state.json", "MAX_BUFFER_SIZE": 999999999})
+        assert c.STATE_FILE == before_state
+        assert c.MAX_BUFFER_SIZE == before_max
+        assert any("STATE_FILE" in w for w in c.USER_CONFIG_WARNINGS)
+        assert any("MAX_BUFFER_SIZE" in w for w in c.USER_CONFIG_WARNINGS)
+
+    def test_bom_prefixed_file_is_read_not_discarded(self, load_cfg):
+        # Notepad / PowerShell Out-File on Windows prepend a UTF-8 BOM. It must be
+        # stripped, not fatal — otherwise the whole file is dropped and PERMISSION_MODE
+        # silently reverts to the bypassPermissions default (a full-access session).
+        c = load_cfg("﻿" + json.dumps({"PERMISSION_MODE": "plan"}))
+        assert c.PERMISSION_MODE == "plan"
+        assert c.USER_CONFIG_WARNINGS == []
+
+    def test_validator_that_raises_degrades_to_warning(self, load_cfg):
+        # _v_dir calls os.path.isdir, which raises "embedded null byte" on Windows for a
+        # path containing \x00. The per-key loop must catch it: a raising validator has to
+        # become a warning, never propagate and abort `from config import *` at launch.
+        default = config.WORKING_DIR
+        c = load_cfg({"WORKING_DIR": "bad\x00dir"})
+        assert c.WORKING_DIR == default
+        assert any("WORKING_DIR" in w for w in c.USER_CONFIG_WARNINGS)
+
+    def test_bad_permission_mode_warning_names_effective_mode(self, load_cfg):
+        # A typo'd read-only intent falls through to the committed default. The warning
+        # must name the mode actually in force so a permissive fallback isn't missed.
+        c = load_cfg({"PERMISSION_MODE": "raed-only"})
+        assert c.PERMISSION_MODE == "bypassPermissions"
+        warning = next(w for w in c.USER_CONFIG_WARNINGS if "PERMISSION_MODE" in w)
+        assert "bypassPermissions" in warning and "full access" in warning

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,6 +5,7 @@ All tests are deterministic and require no network, display, or logged-in CLI.
 Env-var mutations use monkeypatch so they never leak between tests.
 """
 import os
+import json
 import importlib
 
 import pytest
@@ -266,3 +267,118 @@ class TestShotScope:
 
     def test_shot_scope_is_str(self):
         assert isinstance(config.SHOT_SCOPE, str)
+
+
+# ---------------------------------------------------------------------------
+# 8. config.json per-machine overrides
+# ---------------------------------------------------------------------------
+
+class TestUserConfig:
+    """Tests for the config.json override loader (config._apply_user_config).
+
+    Each test writes a temp config.json, points CLAUDE_OVERLAY_CONFIG at it, and
+    reloads config. Teardown restores the previous env value — the suite-wide
+    isolation path set in conftest.py — and reloads once more, so every other test
+    still sees the committed defaults.
+    """
+
+    @pytest.fixture
+    def load_cfg(self, tmp_path):
+        path = tmp_path / "config.json"
+        prev = os.environ.get("CLAUDE_OVERLAY_CONFIG")
+
+        def load(content):
+            text = content if isinstance(content, str) else json.dumps(content)
+            path.write_text(text, "utf-8")
+            os.environ["CLAUDE_OVERLAY_CONFIG"] = str(path)
+            importlib.reload(config)
+            return config
+
+        try:
+            yield load
+        finally:
+            if prev is None:
+                os.environ.pop("CLAUDE_OVERLAY_CONFIG", None)
+            else:
+                os.environ["CLAUDE_OVERLAY_CONFIG"] = prev
+            importlib.reload(config)
+
+    def test_no_file_means_defaults_and_no_warnings(self):
+        # conftest points CLAUDE_OVERLAY_CONFIG at a nonexistent path for the suite.
+        assert config.USER_CONFIG_WARNINGS == []
+        assert config.PERMISSION_MODE == "bypassPermissions"
+
+    def test_overrides_applied(self, load_cfg):
+        c = load_cfg({"PERMISSION_MODE": "plan", "THEME": "dark",
+                      "AUTO_SCREENSHOT_DEFAULT": False})
+        assert c.PERMISSION_MODE == "plan"
+        assert c.THEME == "dark"
+        assert c.T is c.THEMES["dark"]          # T is derived AFTER the overrides
+        assert c.AUTO_SCREENSHOT_DEFAULT is False
+        assert c.USER_CONFIG_WARNINGS == []
+
+    def test_choice_is_case_insensitive_but_canonical(self, load_cfg):
+        # The CLI wants "bypassPermissions" exactly; the file may be sloppier.
+        c = load_cfg({"PERMISSION_MODE": "BYPASSPERMISSIONS"})
+        assert c.PERMISSION_MODE == "bypassPermissions"
+
+    def test_explicit_env_var_beats_file(self, load_cfg, monkeypatch):
+        monkeypatch.setenv("CLAUDE_OVERLAY_SHOT_SCOPE", "window")
+        try:
+            c = load_cfg({"SHOT_SCOPE": "screens"})
+            assert c.SHOT_SCOPE == "window"     # env is a per-launch decision: it wins
+            assert c.USER_CONFIG_WARNINGS == []  # outranked, but not an error
+        finally:
+            # Drop the env var BEFORE the fixture's teardown reload, so the module
+            # isn't left with the env value for later tests.
+            monkeypatch.delenv("CLAUDE_OVERLAY_SHOT_SCOPE", raising=False)
+
+    def test_invalid_value_warns_and_keeps_default(self, load_cfg):
+        c = load_cfg({"PERMISSION_MODE": "yolo"})
+        assert c.PERMISSION_MODE == "bypassPermissions"
+        assert len(c.USER_CONFIG_WARNINGS) == 1
+        assert "PERMISSION_MODE" in c.USER_CONFIG_WARNINGS[0]
+
+    def test_unknown_key_warns(self, load_cfg):
+        c = load_cfg({"PERMISSON_MODE": "plan"})     # typo'd key must be SEEN
+        assert c.PERMISSION_MODE == "bypassPermissions"
+        assert any("PERMISSON_MODE" in w for w in c.USER_CONFIG_WARNINGS)
+
+    def test_corrupt_json_warns_and_keeps_defaults(self, load_cfg):
+        c = load_cfg("{ this is not json")
+        assert c.PERMISSION_MODE == "bypassPermissions"
+        assert c.THEME == "light"
+        assert len(c.USER_CONFIG_WARNINGS) == 1
+
+    def test_top_level_must_be_an_object(self, load_cfg):
+        c = load_cfg("[1, 2, 3]")
+        assert len(c.USER_CONFIG_WARNINGS) == 1
+
+    def test_bool_must_be_json_bool_not_string(self, load_cfg):
+        c = load_cfg({"TASKBAR_BUTTON": "true"})
+        assert c.TASKBAR_BUTTON is True              # default kept
+        assert any("TASKBAR_BUTTON" in w for w in c.USER_CONFIG_WARNINGS)
+
+    def test_numbers_clamp_like_env_int(self, load_cfg):
+        c = load_cfg({"SHOT_JPEG_QUALITY": 200, "WINDOW_ALPHA": 0.05})
+        assert c.SHOT_JPEG_QUALITY == 95
+        assert c.WINDOW_ALPHA == 0.3
+        assert c.USER_CONFIG_WARNINGS == []
+
+    def test_working_dir_accepts_existing_dir(self, load_cfg, tmp_path):
+        c = load_cfg({"WORKING_DIR": str(tmp_path)})
+        assert c.WORKING_DIR == str(tmp_path)
+        assert c.USER_CONFIG_WARNINGS == []
+
+    def test_working_dir_must_exist(self, load_cfg):
+        default = config.WORKING_DIR
+        c = load_cfg({"WORKING_DIR": r"C:\definitely\not\a\real\dir\xyz"})
+        assert c.WORKING_DIR == default              # a bad cwd would break the CLI spawn
+        assert any("WORKING_DIR" in w for w in c.USER_CONFIG_WARNINGS)
+
+    def test_skills_accepts_all_list_and_null(self, load_cfg):
+        assert load_cfg({"SKILLS": "all"}).SKILLS == "all"
+        assert load_cfg({"SKILLS": ["a", "b"]}).SKILLS == ["a", "b"]
+        assert load_cfg({"SKILLS": None}).SKILLS is None
+        c = load_cfg({"SKILLS": 42})
+        assert any("SKILLS" in w for w in c.USER_CONFIG_WARNINGS)


### PR DESCRIPTION
## What

Personalizing the overlay today means editing `config.py` — a tracked source file — so every customized install dirties its git clone, and every `git pull` / `update.cmd` risks a conflict or forces a stash/rebase dance. (I've been carrying a local `PERMISSION_MODE` override plus a rebase-on-launch wrapper just to keep my setup across updates — this PR removes the need for both.)

Settings now come from a tiny per-machine JSON file, read once at import time:

```
%LOCALAPPDATA%\claude-overlay\config.json      ← same folder that already holds state.json
```

```json
{ "PERMISSION_MODE": "plan", "THEME": "dark" }
```

List only what you want to change; everything else keeps the committed default. `CLAUDE_OVERLAY_CONFIG` relocates the file (also how the tests isolate themselves).

## Design

- **Precedence, weakest → strongest:** constants in `config.py` < `config.json` < an explicitly set `CLAUDE_OVERLAY_*` env var (a per-launch decision keeps the rank it always had). The remembered ⚙-toggle state (Window-only / Read-only) still outranks all three — like the constants they replace, `SHOT_SCOPE` / `PERMISSION_MODE` from the file only seed the first launch.
- **Whitelist + per-key validation**, not blind `globals().update()`: choices are case-insensitive but return the canonical spelling the CLI expects (`"bypasspermissions"` → `"bypassPermissions"`), numbers clamp like `_env_int`, `WORKING_DIR` expands `~`/`%VARS%` and must exist (a bad cwd breaks the CLI spawn far less legibly). Derived/structural values (`STATE_FILE`, `THEMES`, `MODELS`, the `MAX_*` safety caps…) stay source-only.
- **Never fatal, never silent:** a broken or typo'd file degrades to the committed defaults, and every skipped key/value is announced in-chat at startup (`⚠ config.json: unknown setting 'PERMISSON_MODE' — ignored.`).

## ⚠ Permission-behavior note (per CONTRIBUTING)

`PERMISSION_MODE` becomes overridable from a file — the same power editing `config.py` already grants, no more. The failure mode that matters is a *typo'd* read-only setting silently yielding a full-access session; that's why skipped entries are surfaced in-chat rather than logged, and why values are validated against the exact set the CLI accepts.

## Tests

- 13 new unit tests for the loader (overrides applied, env-beats-file, canonical choice casing, clamping, corrupt JSON, unknown keys, `SKILLS` forms, `WORKING_DIR` existence).
- `tests/conftest.py` pins `CLAUDE_OVERLAY_CONFIG` to a nonexistent path for the whole suite, so unit tests keep asserting the committed defaults even on a machine that has a personal `config.json`.
- Full suite: 344 passed; the one failure on my machine (`test_copy_btn_puts_text_on_clipboard`) is pre-existing on `main` (another app holds the clipboard) and unrelated.

README **Configuration** section rewritten around the new file (it still pointed at `claude_overlay.py` from before the module split); CHANGELOG entry under **Unreleased** — version left for you to assign at release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)