### PR TITLE
Conversations survive restarts: one-click resume + lossless reconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to Claude Overlay are documented here.
 This project follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- **Conversations survive restarts.** The overlay remembers the CLI session id of your
+  current conversation (per completed turn, in the same per-machine `state.json` as the
+  toggles), and the next launch offers a one-click **↺ Resume last conversation** button
+  in the chat — the transcript isn't replayed, but Claude remembers everything, so you
+  just keep going. Closing the overlay to update it no longer costs you your context.
+  Offered only for a session from the same working directory, younger than
+  `RESUME_OFFER_MAX_AGE` (7 days); **Clear wipes the record**, so a deliberately
+  discarded conversation is never offered back. If the session file is gone, the click
+  falls back to a fresh session with a notice. Set `RESUME_OFFER = False` (or
+  `CLAUDE_OVERLAY_RESUME_OFFER=0`) to never offer.
+
+### Fixed
+- **A transport drop mid-session no longer loses the conversation.** The
+  "↻ Connection hiccup" recovery path used to reconnect with a *fresh* session —
+  silently discarding all context. It now reconnects with `--resume` into the same
+  conversation; only a failed resume falls back to a fresh session (and says so).
+
 ## [1.12.1] — 2026-07-16
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -338,7 +338,10 @@ All settings are constants at the top of `claude_overlay.py`:
   session id is remembered per completed turn; **Clear** wipes it, so a discarded
   conversation is never offered back). `RESUME_OFFER_MAX_AGE` bounds how old a
   conversation may be to qualify (default 7 days). The transcript isn't replayed —
-  Claude just remembers the context and you keep going.
+  Claude just remembers the context and you keep going. Note the overlay resumes the
+  session **it** recorded, not "the latest conversation in this directory" — if you
+  continue that session elsewhere (the CLI or Desktop) afterward, resume still loads its
+  newest state, but the "from … ago" label is measured from the overlay's last turn.
 - `AUTO_SCREENSHOT_DEFAULT`, `FONT_SANS/SERIF/MONO`, `CORNER_RADIUS`, `ORB_SIZE`,
   `HIDE_SCREENSHOT_TOOL`, `WINDOW_ALPHA` — see inline comments.
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ so it uses your **existing Claude subscription — no API key, no metered billin
   edits files, runs commands, and can even reach into the app on your screen (say,
   fix the wording on your open slide, or build a model in your open Excel), not just
   answer questions.
+- 🔁 **Conversations survive restarts.** Relaunch the overlay (say, after an update)
+  and it offers a one-click **Resume last conversation** — and if the connection to
+  the CLI drops mid-session, it reconnects *into the same conversation* instead of
+  losing your context.
 - 💸 **No API key, no extra cost.** Runs on your existing Claude subscription.
 - 🖼️ **Screenshots *and* pasted images.** It grabs your screen automatically on every
   message, or paste any image with **Ctrl+V** to ask about it.
@@ -231,7 +235,9 @@ git pull
 
 > **Then restart the overlay.** It's a long-running process and does **not** reload
 > while running — close it and re-open **`Start Claude Overlay.cmd`** for the update to
-> take effect. (On a managed/enterprise machine, updating is what fixes the older
+> take effect. Your conversation isn't lost: the relaunch offers a one-click
+> **↺ Resume last conversation**, and Claude picks up right where you left off.
+> (On a managed/enterprise machine, updating is what fixes the older
 > versions that could hang on the first tool call.)
 >
 > Updated **by hand** (`git pull`) and the Desktop icon still looks old? Re-run
@@ -327,6 +333,12 @@ All settings are constants at the top of `claude_overlay.py`:
   "active" means the window you were working in before it (tracked automatically), and
   when no usable window exists (fresh launch, desktop focused, window minimized) it
   falls back to full-screen capture rather than sending nothing.
+- `RESUME_OFFER` (or the `CLAUDE_OVERLAY_RESUME_OFFER` env var) — on launch, offer a
+  one-click **↺ Resume last conversation** when the previous run left one behind (the
+  session id is remembered per completed turn; **Clear** wipes it, so a discarded
+  conversation is never offered back). `RESUME_OFFER_MAX_AGE` bounds how old a
+  conversation may be to qualify (default 7 days). The transcript isn't replayed —
+  Claude just remembers the context and you keep going.
 - `AUTO_SCREENSHOT_DEFAULT`, `FONT_SANS/SERIF/MONO`, `CORNER_RADIUS`, `ORB_SIZE`,
   `HIDE_SCREENSHOT_TOOL`, `WINDOW_ALPHA` — see inline comments.
 

--- a/claude_overlay.py
+++ b/claude_overlay.py
@@ -180,6 +180,10 @@ class Overlay:
                                           # launch can offer to resume — see _persist_session
         self._resume_btn = None           # the in-chat "Resume last conversation" button while
                                           # it's still actionable, so events can restyle it
+        self._discard_pending = False     # True from a Clear click until the worker's reset_done
+                                          # drains: a turn's (session / turn_done) batch already
+                                          # queued before the click must not re-set _session_id or
+                                          # re-persist the record and resurrect the discarded chat
         self._restarting = False          # guard: one self-restart (relaunch + quit) at a time
         self._mapping = False             # re-entrancy guard for the <Map> taskbar re-assert
         self._fronting = False            # re-entrancy guard for _raise_to_front (focus churn)
@@ -3187,6 +3191,10 @@ class Overlay:
         # the next launch can't offer to resume a conversation the user threw away.
         self._session_id = None
         self._resume_btn = None          # the embedded button was just wiped with the chat
+        # Guard the window until the worker confirms the reset (reset_done): a stale
+        # (session / turn_done) batch from the turn that was in flight when Clear was
+        # clicked would otherwise re-set _session_id and re-persist the discarded record.
+        self._discard_pending = True
         _save_state(last_session=None)
         self.worker.reset()
         self._set_status("resetting…")
@@ -3579,6 +3587,8 @@ class Overlay:
             self.busy_lbl.configure(text="")
             self._refresh_statusline()
         elif kind == "reset_done":
+            self._discard_pending = False   # worker confirmed the wipe: stale events, if any,
+                                            # have drained ahead of this; the new session is live
             self.add_sys("🔄 new conversation.")
             # Don't null _ctx_pct here: reset() already cleared it on click, and the worker's
             # post-_open _emit_usage has (just before this) pushed the NEW session's real
@@ -3602,9 +3612,12 @@ class Overlay:
             self._finish_turn_copy()     # then a Copy button under the reply
             self._set_busy(False)
             self._maybe_flag_done()      # badge the orb if this finished while collapsed
-            self._persist_session()      # this conversation is now the resumable one
+            if not self._discard_pending:
+                self._persist_session()  # this conversation is now the resumable one
+                                         # (skipped for a turn Cleared mid-flight)
         elif kind == "session":
-            self._session_id = str(payload)
+            if not self._discard_pending:   # ignore a stale id from a Cleared conversation
+                self._session_id = str(payload)
         elif kind == "resumed":
             self._set_status("")
             if self._resume_btn is not None:
@@ -3618,6 +3631,18 @@ class Overlay:
             self._persist_session()      # keep it resumable even if no new turn follows
         elif kind == "resume_failed":
             self._set_status("")
+            if self._resume_btn is not None:
+                try:
+                    self._resume_btn._set_ustate("failed")
+                except Exception:
+                    pass
+                self._resume_btn = None
+        elif kind == "resume_lost":
+            # The connect looked like a resume, but the CLI's first streamed id proves it
+            # silently started FRESH (see worker._set_session). Correct the earlier
+            # optimistic "resumed" so the user isn't told the context is back when it isn't.
+            self.add_err("⚠ The previous conversation couldn't be restored after all — the "
+                         "CLI started a fresh session, so earlier context isn't available.")
             if self._resume_btn is not None:
                 try:
                     self._resume_btn._set_ustate("failed")

--- a/claude_overlay.py
+++ b/claude_overlay.py
@@ -175,6 +175,11 @@ class Overlay:
         self._update_available = None     # set to the newer version string if one exists
         self._cli_update_shown = False    # show the "CLI is out of date" notice at most once/session
         self._cli_update_btn_ref = None   # the in-chat Update button, so its result can restyle it
+        self._session_id = None           # the CLI's id for the current conversation (worker
+                                          # events); persisted per completed turn so the NEXT
+                                          # launch can offer to resume — see _persist_session
+        self._resume_btn = None           # the in-chat "Resume last conversation" button while
+                                          # it's still actionable, so events can restyle it
         self._restarting = False          # guard: one self-restart (relaunch + quit) at a time
         self._mapping = False             # re-entrancy guard for the <Map> taskbar re-assert
         self._fronting = False            # re-entrancy guard for _raise_to_front (focus churn)
@@ -280,6 +285,7 @@ class Overlay:
                          "Read-only toggle off for full access." if self.read_only else
                          "⚡ Full access restored from your last session (you had "
                          "switched Read-only off). Flip it back on any time.")
+        self._maybe_offer_resume()
 
         self.root.after(130, lambda: (self.root.focus_force(), self.entry.focus_set()))
         self.root.bind("<Configure>", self._on_configure)
@@ -2527,6 +2533,119 @@ class Overlay:
         self._ins("\n⚠  " + ("" if text is None else str(text)) + "\n", "err")
 
     # ── "your CLI is out of date" notice + one-click update (see cliupdate.py) ──────────
+    def _maybe_offer_resume(self):
+        """On launch, if the previous run left a conversation behind (its session id is
+        persisted on every completed turn — see _persist_session), drop a one-click
+        Resume button into the chat. Only for a session from the SAME working dir (the
+        CLI stores sessions per directory) and not too old; Clear wipes the record, so
+        a deliberately discarded conversation is never offered back."""
+        if not RESUME_OFFER:
+            return
+        saved = _load_state().get("last_session")
+        if not (isinstance(saved, dict) and saved.get("id")):
+            return
+        if saved.get("cwd") != WORKING_DIR:
+            return
+        ts = saved.get("ts")
+        age = (time.time() - ts) if isinstance(ts, (int, float)) else -1
+        if not (0 <= age <= RESUME_OFFER_MAX_AGE):
+            return
+        self.add_sys(f"💬 You have a conversation from {self._age_str(age)} ago. "
+                     "Claude can pick it up where you left off:")
+        at_bottom = self.chat.yview()[1] > 0.999
+        self.chat.insert("end", "\n")
+        self.chat.window_create("end", window=self._resume_btn_widget(str(saved["id"])),
+                                padx=self.px(16), pady=self.px(2))
+        self.chat.insert("end", "\n")
+        if at_bottom:
+            self.chat.see("end")
+
+    @staticmethod
+    def _age_str(secs):
+        """Coarse '5 min' / '3 h' / '2 d' for the resume offer — false precision would
+        just be noise."""
+        secs = max(0, int(secs))
+        if secs < 3600:
+            return f"{max(1, secs // 60)} min"
+        if secs < 86400:
+            return f"{secs // 3600} h"
+        return f"{secs // 86400} d"
+
+    def _resume_btn_widget(self, session_id):
+        """One-click 'Resume last conversation' button embedded in the chat (same
+        embedded-canvas pattern as the CLI-update button, incl. the forwarded wheel).
+        Click asks the worker to relaunch the client with --resume; the outcome comes
+        back as a ('resumed') / ('resume_failed') event that restyles this exact
+        button. Once a NEW conversation starts (first send), the button goes stale —
+        clicking it then would silently discard the messages just exchanged."""
+        c = tk.Canvas(self.chat, bg=T["bg"], highlightthickness=0, cursor="hand2",
+                      takefocus=0)
+        c._ustate = "idle"                          # idle | working | done | failed | stale
+        st = {"f": None, "w": 0, "h": 0, "rad": 0}  # current-zoom font + box, set by render()
+        labels = {"idle": "↺  Resume last conversation",
+                  "working": "Resuming…",
+                  "done": "✓  Resumed — keep going",
+                  "failed": "⚠  Couldn't resume — this is a fresh session",
+                  "stale": "↺  (a new conversation has started)"}
+
+        def draw(hover=False):
+            c.delete("all")
+            s = c._ustate
+            if s == "idle":
+                bg = T["accent_hi"] if hover else T["accent"]
+                fg = T["on_accent"]
+            elif s == "failed":
+                bg, fg = T["tool_bg"], T["err"]
+            else:                                   # working / done / stale → inert grey
+                bg, fg = T["tool_bg"], T["muted"]
+            round_rect(c, 1, 1, st["w"] - 1, st["h"] - 1, st["rad"], fill=bg, outline="")
+            c.create_text(st["w"] / 2, st["h"] / 2, text=labels[c._ustate], fill=fg,
+                          font=st["f"], anchor="center")
+
+        def render():
+            f = tkfont.Font(root=self.root, font=self.f_small)   # current zoom
+            c._overlay_fonts = [f]                               # keep a ref so Tk won't GC it
+            pad = self.px(11)
+            widest = max(f.measure(v) for v in labels.values())  # widest state → no reflow
+            st.update(f=f, h=self.px(24), rad=self.px(7), w=pad + widest + pad)
+            c.configure(width=st["w"], height=st["h"])
+            draw()
+
+        def set_state(s):
+            c._ustate = s
+            try:
+                c.configure(cursor="hand2" if s == "idle" else "arrow")
+                draw()
+            except Exception:
+                pass
+        c._set_ustate = set_state    # let the resumed/resume_failed handlers restyle it
+
+        def on_click(_e):
+            if c._ustate != "idle" or self.busy:
+                return "break"
+            set_state("working")
+            self._set_status("resuming last conversation…")
+            self.worker.resume(session_id)
+            return "break"
+        c._click = on_click          # a named handle so the routing is directly testable
+
+        render()
+        c.bind("<Enter>", lambda e: draw(hover=True))
+        c.bind("<Leave>", lambda e: draw(hover=False))
+        c.bind("<Button-1>", on_click)
+        c.bind("<MouseWheel>", self._fwd_wheel)      # embedded widget must not swallow scroll
+        self._register_zoomable(c, render)
+        self._resume_btn = c
+        return c
+
+    def _persist_session(self):
+        """Record the current conversation's session id (+ when and where) so the next
+        launch can offer to resume it. Called per completed turn — cheap (a tiny JSON
+        write) and crash-safe: whatever the last finished turn was, that's resumable."""
+        if self._session_id:
+            _save_state(last_session={"id": self._session_id, "ts": time.time(),
+                                      "cwd": WORKING_DIR})
+
     def _show_cli_update_notice(self, info):
         """Render the 'CLI is behind' notice + a one-click Update button in the chat. Shown at
         most once per session (guarded), and only reached when cliupdate found the CLI behind."""
@@ -2727,6 +2846,12 @@ class Overlay:
         if n:
             label += (f"   🖼×{n}" if n > 1 else "   🖼")
         self.add_user(label)
+        if self._resume_btn is not None:   # a NEW conversation is starting — resuming now
+            try:                           # would silently discard it; retire the offer
+                self._resume_btn._set_ustate("stale")
+            except Exception:
+                pass
+            self._resume_btn = None
         if IMAGE_INPUT == "inline":
             paths = [s["path"] for s in (shots or [])] + list(images)
             self.worker.ask(self._inline_text(text, shots, images), paths)
@@ -3058,6 +3183,11 @@ class Overlay:
         # worker's post-_open _emit_usage.
         self._ctx_pct = None
         self._refresh_statusline()
+        # Clear = deliberate discard: forget the session AND its persisted record, so
+        # the next launch can't offer to resume a conversation the user threw away.
+        self._session_id = None
+        self._resume_btn = None          # the embedded button was just wiped with the chat
+        _save_state(last_session=None)
         self.worker.reset()
         self._set_status("resetting…")
         # Chat was just wiped — drop the compaction banner/timer so a stray result line
@@ -3472,6 +3602,28 @@ class Overlay:
             self._finish_turn_copy()     # then a Copy button under the reply
             self._set_busy(False)
             self._maybe_flag_done()      # badge the orb if this finished while collapsed
+            self._persist_session()      # this conversation is now the resumable one
+        elif kind == "session":
+            self._session_id = str(payload)
+        elif kind == "resumed":
+            self._set_status("")
+            if self._resume_btn is not None:
+                try:
+                    self._resume_btn._set_ustate("done")
+                except Exception:
+                    pass
+                self._resume_btn = None
+            self.add_sys("↺ Resumed your last conversation. The transcript isn't "
+                         "replayed here, but Claude remembers it — just keep going.")
+            self._persist_session()      # keep it resumable even if no new turn follows
+        elif kind == "resume_failed":
+            self._set_status("")
+            if self._resume_btn is not None:
+                try:
+                    self._resume_btn._set_ustate("failed")
+                except Exception:
+                    pass
+                self._resume_btn = None
         elif kind == "compacting":
             self._start_compact_anim()
         elif kind == "compact_done":

--- a/config.py
+++ b/config.py
@@ -211,6 +211,16 @@ CLI_UPDATE_CHECK = _env_bool("CLAUDE_OVERLAY_CLI_UPDATE_CHECK", True)   # on lau
                             # the overlay current never advances the CLI, and an old CLI silently
                             # runs an older model. Set CLAUDE_OVERLAY_CLI_UPDATE_CHECK=0 to disable
                             # (e.g. a locked-down box where global npm installs aren't allowed)
+RESUME_OFFER = _env_bool("CLAUDE_OVERLAY_RESUME_OFFER", True)   # on launch, when the previous
+                            # run left a conversation behind, show a one-click "Resume last
+                            # conversation" button in the chat. The session id is remembered
+                            # (in STATE_FILE) on every completed turn; Clear wipes the record,
+                            # so a deliberately discarded conversation is never offered back.
+                            # Set CLAUDE_OVERLAY_RESUME_OFFER=0 to never offer.
+RESUME_OFFER_MAX_AGE = 7 * 24 * 3600   # only offer to resume a conversation younger than this
+                            # (seconds). Days-old context is rarely what you want back, and the
+                            # CLI eventually cleans up old session files anyway (then a click
+                            # would just fall back to a fresh session with a notice).
 
 SYSTEM_APPEND = (
     "You are running as an always-on-top floating overlay assistant on the user's "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,6 +127,8 @@ def _clean_overlay(ov):
     ov.pending_images = []
     ov.pending_shot = None
     ov._precaptured = None
+    ov._discard_pending = False         # reset() sets it True; a real run clears it on the
+                                        # worker's reset_done, which the fixture never delivers
     ov._capture_busy = False
     ov._paste_busy = False
     ov._send_hover = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,7 @@ class FakeWorker:
     def reset(self):            self._rec("reset")
     def compact(self):          self._rec("compact")
     def set_model(self, *a):    self._rec("set_model", *a)
+    def resume(self, *a):       self._rec("resume", *a)
     def set_permission_mode(self, *a):  self._rec("set_permission_mode", *a)
     def interrupt(self):        self._rec("interrupt")
     def shutdown(self):         self._rec("shutdown")

--- a/tests/test_ui_resume.py
+++ b/tests/test_ui_resume.py
@@ -1,0 +1,151 @@
+"""UI feature tests for session resume:
+  - _maybe_offer_resume gating (state present/absent, wrong cwd, too old)
+  - the in-chat Resume button (click routing, restyling via resumed/resume_failed)
+  - _persist_session on turn_done, and reset() wiping the record
+  - the offer going stale once a new conversation starts
+  - _age_str
+"""
+import time
+
+import pytest
+from conftest import chat_text
+
+import claude_overlay as co
+
+
+def _seed_last_session(sid="sess-1", **overrides):
+    """Write a resumable-looking record into the (throwaway) STATE_FILE."""
+    rec = {"id": sid, "ts": time.time(), "cwd": co.WORKING_DIR}
+    rec.update(overrides)
+    co._save_state(last_session=rec)
+    return rec
+
+
+# ── _age_str ─────────────────────────────────────────────────────────────────
+
+def test_age_str_minutes():
+    assert co.Overlay._age_str(0) == "1 min"          # never "0 min"
+    assert co.Overlay._age_str(5 * 60) == "5 min"
+
+def test_age_str_hours_and_days():
+    assert co.Overlay._age_str(3 * 3600) == "3 h"
+    assert co.Overlay._age_str(2 * 86400 + 5) == "2 d"
+
+
+# ── _maybe_offer_resume gating ───────────────────────────────────────────────
+
+def test_offer_shown_for_fresh_same_cwd_session(overlay):
+    _seed_last_session()
+    overlay._maybe_offer_resume()
+    assert overlay._resume_btn is not None
+    assert overlay._resume_btn._ustate == "idle"
+    assert "pick it up where you left off" in chat_text(overlay)
+
+def test_no_offer_without_saved_session(overlay):
+    co._save_state(last_session=None)
+    overlay._maybe_offer_resume()
+    assert overlay._resume_btn is None
+
+def test_no_offer_for_other_working_dir(overlay):
+    # CLI sessions are stored per directory — a record from elsewhere can't resume here.
+    _seed_last_session(cwd=r"C:\somewhere\else")
+    overlay._maybe_offer_resume()
+    assert overlay._resume_btn is None
+
+def test_no_offer_for_too_old_session(overlay):
+    _seed_last_session(ts=time.time() - co.RESUME_OFFER_MAX_AGE - 60)
+    overlay._maybe_offer_resume()
+    assert overlay._resume_btn is None
+
+def test_no_offer_for_malformed_record(overlay):
+    co._save_state(last_session={"ts": time.time(), "cwd": co.WORKING_DIR})  # no id
+    overlay._maybe_offer_resume()
+    assert overlay._resume_btn is None
+    co._save_state(last_session="sess-1")                                    # not a dict
+    overlay._maybe_offer_resume()
+    assert overlay._resume_btn is None
+
+
+# ── the Resume button ────────────────────────────────────────────────────────
+
+def test_click_routes_to_worker_and_goes_working(overlay):
+    _seed_last_session("sess-42")
+    overlay._maybe_offer_resume()
+    btn = overlay._resume_btn
+    btn._click(None)
+    assert ("resume", ("sess-42",)) in overlay.worker.calls
+    assert btn._ustate == "working"
+
+def test_click_ignored_while_busy(overlay):
+    _seed_last_session("sess-42")
+    overlay._maybe_offer_resume()
+    overlay.busy = True
+    overlay._resume_btn._click(None)
+    assert all(name != "resume" for name, _ in overlay.worker.calls)
+    assert overlay._resume_btn._ustate == "idle"
+
+def test_second_click_while_working_is_inert(overlay):
+    _seed_last_session("sess-42")
+    overlay._maybe_offer_resume()
+    btn = overlay._resume_btn
+    btn._click(None)
+    btn._click(None)
+    assert sum(1 for name, _ in overlay.worker.calls if name == "resume") == 1
+
+def test_resumed_event_restyles_and_announces(overlay):
+    _seed_last_session("sess-42")
+    overlay._maybe_offer_resume()
+    btn = overlay._resume_btn
+    overlay._session_id = "sess-42"
+    overlay._handle("resumed", None)
+    assert btn._ustate == "done"
+    assert overlay._resume_btn is None            # no longer actionable
+    assert "Resumed your last conversation" in chat_text(overlay)
+
+def test_resume_failed_event_restyles(overlay):
+    _seed_last_session("sess-42")
+    overlay._maybe_offer_resume()
+    btn = overlay._resume_btn
+    overlay._handle("resume_failed", None)
+    assert btn._ustate == "failed"
+    assert overlay._resume_btn is None
+
+def test_offer_goes_stale_when_new_conversation_starts(overlay):
+    _seed_last_session("sess-42")
+    overlay._maybe_offer_resume()
+    btn = overlay._resume_btn
+    overlay.auto_shot = False                     # keep the send path off real capture
+    overlay.entry.insert("1.0", "hello")
+    overlay._ph_active = False
+    overlay._send_or_stop()
+    assert ("ask" in {name for name, _ in overlay.worker.calls})
+    assert btn._ustate == "stale"
+    assert overlay._resume_btn is None
+    # a stale button must not route clicks anymore
+    btn._click(None)
+    assert all(name != "resume" for name, _ in overlay.worker.calls)
+
+
+# ── persistence ──────────────────────────────────────────────────────────────
+
+def test_turn_done_persists_current_session(overlay):
+    overlay._handle("session", "sess-9")
+    overlay._handle("turn_done", None)
+    saved = co._load_state().get("last_session")
+    assert isinstance(saved, dict)
+    assert saved["id"] == "sess-9"
+    assert saved["cwd"] == co.WORKING_DIR
+    assert abs(time.time() - saved["ts"]) < 5
+
+def test_turn_done_without_session_keeps_existing_record(overlay):
+    rec = _seed_last_session("sess-old")
+    overlay._session_id = None
+    overlay._handle("turn_done", None)            # e.g. an errored turn before init
+    assert co._load_state().get("last_session")["id"] == rec["id"]
+
+def test_reset_wipes_the_record(overlay):
+    _seed_last_session("sess-9")
+    overlay._session_id = "sess-9"
+    overlay.reset()
+    assert co._load_state().get("last_session") is None
+    assert overlay._session_id is None

--- a/tests/test_ui_resume.py
+++ b/tests/test_ui_resume.py
@@ -110,6 +110,17 @@ def test_resume_failed_event_restyles(overlay):
     assert btn._ustate == "failed"
     assert overlay._resume_btn is None
 
+def test_resume_lost_event_corrects_the_claim(overlay):
+    # The worker reported the CLI silently started fresh after an optimistic "resumed":
+    # the button flips to failed and the chat says the context isn't actually back.
+    _seed_last_session("sess-42")
+    overlay._maybe_offer_resume()
+    btn = overlay._resume_btn
+    overlay._handle("resume_lost", None)
+    assert btn._ustate == "failed"
+    assert overlay._resume_btn is None
+    assert "couldn't be restored" in chat_text(overlay)
+
 def test_offer_goes_stale_when_new_conversation_starts(overlay):
     _seed_last_session("sess-42")
     overlay._maybe_offer_resume()
@@ -149,3 +160,26 @@ def test_reset_wipes_the_record(overlay):
     overlay.reset()
     assert co._load_state().get("last_session") is None
     assert overlay._session_id is None
+
+def test_clear_race_stale_events_dont_resurrect(overlay):
+    # A turn's (session / turn_done) batch enqueued just before Clear must not re-set the
+    # id or re-persist the record while the discard is pending — the worker's reset_done
+    # hasn't drained yet. (#5 review, finding 2.)
+    overlay._handle("session", "sess-live")
+    overlay._handle("turn_done", None)
+    assert co._load_state()["last_session"]["id"] == "sess-live"
+
+    overlay.reset()                               # user clicks Clear
+    assert overlay._discard_pending is True
+    assert co._load_state().get("last_session") is None
+
+    overlay._handle("session", "sess-live")       # stale batch drains AFTER the click
+    overlay._handle("turn_done", None)
+    assert overlay._session_id is None            # not resurrected
+    assert co._load_state().get("last_session") is None
+
+    overlay._handle("reset_done", None)           # worker confirms the wipe
+    assert overlay._discard_pending is False
+    overlay._handle("session", "sess-new")        # a genuine new turn persists again
+    overlay._handle("turn_done", None)
+    assert co._load_state()["last_session"]["id"] == "sess-new"

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -676,3 +676,146 @@ class TestLaunchPermissionMode:
     def test_launch_mode_default_follows_config(self):
         w = make_worker()
         assert w._permission_mode == config.PERMISSION_MODE
+
+
+# ---------------------------------------------------------------------------
+# Session tracking + resume (the "conversations survive restarts" feature)
+# ---------------------------------------------------------------------------
+
+class TestSessionTracking:
+    """Session-id capture from stream messages, and how resume flows through the
+    worker. Still no .start()/.run()/connect — the async bits are exercised with
+    stubbed _open/_close on a throwaway event loop."""
+
+    def test_resume_enqueues(self):
+        w = make_worker()
+        w.resume("sess-1")
+        assert w.req.get_nowait() == ("resume", "sess-1")
+
+    def test_resume_coerces_id_to_str(self):
+        w = make_worker()
+        w.resume(12345)
+        assert w.req.get_nowait() == ("resume", "12345")
+
+    def test_set_session_records_and_emits(self):
+        w = make_worker()
+        w._set_session("s-abc")
+        assert w._session_id == "s-abc"
+        assert w.ui.get_nowait() == ("session", "s-abc")
+
+    def test_set_session_same_id_emits_once(self):
+        w = make_worker()
+        w._set_session("s-abc")
+        w.ui.get_nowait()
+        w._set_session("s-abc")          # unchanged → no duplicate UI event
+        assert w.ui.empty()
+
+    def test_set_session_ignores_empty(self):
+        w = make_worker()
+        w._set_session(None)
+        w._set_session("")
+        assert w._session_id is None
+        assert w.ui.empty()
+
+    def test_result_message_captures_session_id(self):
+        from claude_agent_sdk import ResultMessage
+        w = make_worker()
+        msg = ResultMessage(subtype="success", duration_ms=1, duration_api_ms=1,
+                            is_error=False, num_turns=1, session_id="s-result")
+        w._dispatch(msg, {})
+        assert w._session_id == "s-result"
+
+    def test_system_init_captures_session_id(self):
+        from claude_agent_sdk import SystemMessage
+        w = make_worker()
+        w._dispatch(SystemMessage(subtype="init", data={"session_id": "s-init"}), {})
+        assert w._session_id == "s-init"
+
+    def test_system_non_init_is_ignored(self):
+        from claude_agent_sdk import SystemMessage
+        w = make_worker()
+        w._dispatch(SystemMessage(subtype="status", data={"session_id": "s-x"}), {})
+        assert w._session_id is None
+
+    def test_make_options_passes_resume(self):
+        w = make_worker()
+        w._resume_session_id = "s-9"
+        opts = w._make_options()
+        assert getattr(opts, "resume", None) == "s-9"
+
+    def test_make_options_no_resume_by_default(self):
+        w = make_worker()
+        opts = w._make_options()
+        assert getattr(opts, "resume", None) is None
+
+
+class TestReconnectResume:
+    """_reconnect must carry the known session id into the next _open (context
+    preserved across a dead transport), and say which of the two things it's doing."""
+
+    def _run_reconnect(self, w):
+        async def _noop():
+            return None
+        w._close = lambda: _noop()
+        w._open = lambda: _noop()        # capture happens BEFORE _open would consume it
+        asyncio.run(w._reconnect())
+
+    def test_reconnect_with_session_resumes(self):
+        w = make_worker()
+        w._session_id = "s-live"
+        self._run_reconnect(w)
+        assert w._resume_session_id == "s-live"
+        kind, text = w.ui.get_nowait()
+        assert kind == "system" and "resum" in text.lower()
+
+    def test_reconnect_without_session_is_fresh(self):
+        w = make_worker()
+        self._run_reconnect(w)
+        assert w._resume_session_id is None
+        kind, text = w.ui.get_nowait()
+        assert kind == "system" and "fresh" in text.lower()
+
+
+class TestDoResume:
+    """_do_resume outcome signalling: 'resumed' only when the client is up AND the
+    session id stuck; anything else must tell the UI the resume failed."""
+
+    @staticmethod
+    def _stub(w, client, session_after):
+        async def _close():
+            return None
+
+        async def _open():
+            # mimic _open's contract: success adopts the pending id, either way it's consumed
+            w._client = client
+            w._session_id = session_after
+            w._resume_session_id = None
+        w._close = _close
+        w._open = _open
+
+    def test_success_emits_resumed(self):
+        w = make_worker()
+        self._stub(w, client=object(), session_after="s-1")
+        asyncio.run(w._do_resume("s-1"))
+        kinds = []
+        while not w.ui.empty():
+            kinds.append(w.ui.get_nowait()[0])
+        assert "resumed" in kinds and "resume_failed" not in kinds
+
+    def test_fallback_emits_resume_failed(self):
+        w = make_worker()
+        self._stub(w, client=object(), session_after=None)   # fresh-session fallback
+        asyncio.run(w._do_resume("s-1"))
+        kinds = []
+        while not w.ui.empty():
+            kinds.append(w.ui.get_nowait()[0])
+        assert "resume_failed" in kinds and "resumed" not in kinds
+
+    def test_no_client_emits_resume_failed(self):
+        w = make_worker()
+        self._stub(w, client=None, session_after=None)
+        asyncio.run(w._do_resume("s-1"))
+        kinds = []
+        while not w.ui.empty():
+            kinds.append(w.ui.get_nowait()[0])
+        assert "resume_failed" in kinds

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -25,6 +25,14 @@ def make_worker():
     return ClaudeWorker(queue.Queue())
 
 
+def _drain(q):
+    """Every (kind, payload) the worker queued onto its UI queue, in order."""
+    out = []
+    while not q.empty():
+        out.append(q.get_nowait())
+    return out
+
+
 # ---------------------------------------------------------------------------
 # 1. Enqueue helpers
 # ---------------------------------------------------------------------------
@@ -778,24 +786,31 @@ class TestReconnectResume:
 
 class TestDoResume:
     """_do_resume outcome signalling: 'resumed' only when the client is up AND the
-    session id stuck; anything else must tell the UI the resume failed."""
+    resume was genuinely honoured (_resume_ok); anything else tells the UI it failed.
+    Reporting off _resume_ok, not `_session_id == sid`, is the fix for #5's blocking
+    finding — _open force-sets _session_id to the pending id, so that equality was
+    always true and validated nothing."""
 
     @staticmethod
-    def _stub(w, client, session_after):
+    def _stub(w, client, resume_ok):
         async def _close():
             return None
 
         async def _open():
-            # mimic _open's contract: success adopts the pending id, either way it's consumed
+            # mimic the real _open contract: a genuine resume adopts the pending id and
+            # sets _resume_ok; a fresh fallback leaves _resume_ok False. Either way the
+            # pending id is consumed.
             w._client = client
-            w._session_id = session_after
+            if resume_ok:
+                w._session_id = w._resume_session_id
+                w._resume_ok = True
             w._resume_session_id = None
         w._close = _close
         w._open = _open
 
     def test_success_emits_resumed(self):
         w = make_worker()
-        self._stub(w, client=object(), session_after="s-1")
+        self._stub(w, client=object(), resume_ok=True)
         asyncio.run(w._do_resume("s-1"))
         kinds = []
         while not w.ui.empty():
@@ -804,7 +819,7 @@ class TestDoResume:
 
     def test_fallback_emits_resume_failed(self):
         w = make_worker()
-        self._stub(w, client=object(), session_after=None)   # fresh-session fallback
+        self._stub(w, client=object(), resume_ok=False)   # connected, but fresh session
         asyncio.run(w._do_resume("s-1"))
         kinds = []
         while not w.ui.empty():
@@ -813,9 +828,105 @@ class TestDoResume:
 
     def test_no_client_emits_resume_failed(self):
         w = make_worker()
-        self._stub(w, client=None, session_after=None)
+        self._stub(w, client=None, resume_ok=False)
         asyncio.run(w._do_resume("s-1"))
         kinds = []
         while not w.ui.empty():
             kinds.append(w.ui.get_nowait()[0])
         assert "resume_failed" in kinds
+
+    def test_sets_resume_expected_for_streamed_verification(self):
+        # _do_resume must arm the streamed-init backstop (_resume_expected) so a CLI that
+        # accepts --resume but silently starts fresh is caught on the first message.
+        w = make_worker()
+        seen = {}
+
+        async def _close():
+            return None
+
+        async def _open():
+            seen["expected_at_open"] = w._resume_expected
+            w._client = object()
+            w._resume_ok = True
+            w._resume_session_id = None
+        w._close, w._open = _close, _open
+        asyncio.run(w._do_resume("s-1"))
+        assert seen["expected_at_open"] == "s-1"
+
+
+class TestOpenResumeContract:
+    """The real _open resume path (not stubbed): force-set is backed by _resume_ok, and
+    an SDK too old for --resume is reported as a resume failure, never silent success."""
+
+    def _stub_open_once(self, w, results):
+        # results: list of booleans returned by successive _open_once calls.
+        calls = {"n": 0}
+
+        async def _open_once(quiet=False):
+            i = calls["n"]
+            calls["n"] += 1
+            w._client = object() if results[i] else None
+            return results[i]
+        w._open_once = _open_once
+        return calls
+
+    def test_genuine_resume_sets_resume_ok(self):
+        w = make_worker()
+        self._stub_open_once(w, [True])          # resume connect succeeds
+        w._resume_session_id = "s-1"
+        w._last_dropped = []                     # SDK supports --resume
+        asyncio.run(w._open())
+        assert w._resume_ok is True
+        assert w._session_id == "s-1"
+
+    def test_old_sdk_dropping_resume_is_not_reported_resumed(self):
+        w = make_worker()
+        self._stub_open_once(w, [True])          # connect "succeeds" — but fresh
+        w._resume_session_id = "s-1"
+        w._last_dropped = ["resume"]             # _make_options had to strip --resume
+        asyncio.run(w._open())
+        assert w._resume_ok is False             # so _do_resume reports resume_failed
+        assert w._resume_expected is None
+        msgs = [t for k, t in _drain(w.ui) if k == "system"]
+        assert any("too old" in m for m in msgs)
+
+    def test_vanished_session_falls_back_to_fresh(self):
+        w = make_worker()
+        self._stub_open_once(w, [False, True])   # resume connect fails, fresh retry works
+        w._resume_session_id = "s-gone"
+        w._last_dropped = []
+        asyncio.run(w._open())
+        assert w._resume_ok is False
+        assert w._resume_expected is None
+        msgs = [t for k, t in _drain(w.ui) if k == "system"]
+        assert any("starting fresh" in m for m in msgs)
+
+
+class TestResumeStreamedVerification:
+    """_set_session backstops the 'accepted --resume but silently started fresh' case:
+    when the streamed id differs from the one we asked to resume, flag resume_lost."""
+
+    def test_mismatched_streamed_id_flags_resume_lost(self):
+        w = make_worker()
+        w._session_id = "s-old"          # _open force-set this to the pending id
+        w._resume_expected = "s-old"
+        w._set_session("s-fresh")        # CLI answered with a DIFFERENT id
+        kinds = dict(_drain(w.ui))
+        assert "resume_lost" in kinds
+        assert w._session_id == "s-fresh"   # the fresh session becomes the live one
+        assert w._resume_expected is None   # expectation consumed
+
+    def test_matching_streamed_id_is_quiet(self):
+        w = make_worker()
+        w._session_id = "s-keep"
+        w._resume_expected = "s-keep"
+        w._set_session("s-keep")         # genuine resume: same id comes back
+        assert w.ui.empty()              # no resume_lost, no duplicate session event
+        assert w._resume_expected is None
+
+    def test_no_expectation_behaves_normally(self):
+        w = make_worker()
+        w._set_session("s-1")            # ordinary turn, no resume in flight
+        events = _drain(w.ui)
+        assert ("resume_lost", None) not in events
+        assert ("session", "s-1") in events

--- a/worker.py
+++ b/worker.py
@@ -97,11 +97,23 @@ class ClaudeWorker(threading.Thread):
         # session STARTS in bypass mode. Re-derived on every _open() (a reconnect that
         # happens while read-only relaunches without the flag).
         self._bypass_capable = (self._permission_mode == "bypassPermissions")
+        # The CLI's id for the CURRENT conversation, captured from init/result stream
+        # messages (_set_session). The UI persists it on every completed turn so the
+        # NEXT launch can offer to resume the conversation; _reconnect uses it so a
+        # dead transport no longer costs the user their context.
+        self._session_id = None
+        # When set, the next _open() launches the CLI with --resume <id> (consumed
+        # there; a failed resume falls back to ONE fresh attempt).
+        self._resume_session_id = None
 
     def ask(self, text: str, image_paths=None):
         self.req.put(("ask", (text, list(image_paths or []))))
     def reset(self):                  self.req.put(("reset", None))
     def compact(self):                self.req.put(("compact", None))
+    def resume(self, session_id):
+        # Queued like reset (serialized behind in-flight work): swap the live client
+        # for one that resumes <session_id>. Driven by the launch-time Resume button.
+        self.req.put(("resume", str(session_id)))
     def shutdown(self):
         self._running = False
         # If the worker is currently AWAITING a lifecycle call (connect/disconnect), the
@@ -252,6 +264,10 @@ class ClaudeWorker(threading.Thread):
             # Skill tool + sets setting_sources=["user","project"] when this is provided; left
             # unset the overlay discovers no skills at all. A list enables only those skills.
             opts["skills"] = SKILLS
+        if self._resume_session_id:
+            # Relaunch INTO a previous conversation: the launch-time Resume button, or
+            # a reconnect carrying the live session across a dead transport (_reconnect).
+            opts["resume"] = self._resume_session_id
         if STRICT_MCP_CONFIG:
             # Use ONLY the (empty) MCP servers defined here, ignoring the user's filesystem
             # config. Without this the spawned CLI loads every MCP server from ~/.claude.json
@@ -264,7 +280,7 @@ class ClaudeWorker(threading.Thread):
         # SDKs. Strip any the installed SDK rejects, one at a time, so an older install still
         # loads (with reduced features) instead of failing to construct options at all.
         droppable = ["strict_mcp_config", "max_buffer_size", "can_use_tool",
-                     "include_partial_messages", "skills", "disallowed_tools"]
+                     "include_partial_messages", "skills", "disallowed_tools", "resume"]
         while True:
             try:
                 return ClaudeAgentOptions(**opts)
@@ -341,12 +357,17 @@ class ClaudeWorker(threading.Thread):
                 if kind == "reset":
                     await self._close()
                     self._saw_stream = False
+                    self._session_id = None          # Clear = deliberate discard: neither a
+                    self._resume_session_id = None   # reconnect nor the next launch may
+                                                     # resurrect the wiped conversation
                     await self._open()
                     self.ui.put(("reset_done", None))
                 elif kind == "ask":
                     await self._run_turn(payload)
                 elif kind == "compact":
                     await self._run_compact()
+                elif kind == "resume":
+                    await self._do_resume(payload)
                 elif kind == "set_model":
                     if self._client is None:
                         self.ui.put(("error", "Not connected to Claude yet — can't switch model."))
@@ -371,18 +392,72 @@ class ClaudeWorker(threading.Thread):
         await self._close()
 
     async def _reconnect(self):
-        """Tear down a broken client and stand up a fresh one so the next turn works.
-        The conversation context is lost (new session), but the app stays alive instead
-        of freezing on a dead transport."""
-        self.ui.put(("system", "↻ Connection hiccup — reconnected with a fresh session."))
+        """Tear down a broken client and stand up a working one so the next turn works.
+        When the session id is known, reconnect WITH it (--resume) so the conversation
+        survives the transport dying — historically this path silently cost the user
+        their whole context. Only a failed resume falls back to a fresh session (and
+        _open announces that fallback)."""
+        sid = self._session_id
+        self.ui.put(("system",
+                     "↻ Connection hiccup — reconnecting and resuming the conversation…"
+                     if sid else
+                     "↻ Connection hiccup — reconnected with a fresh session."))
         try:
             await self._close()
         except Exception:
             pass
         self._saw_stream = False
+        self._resume_session_id = sid
         await self._open()
 
+    async def _do_resume(self, session_id):
+        """Swap the live client for one launched with --resume <id>: the previous
+        conversation's context comes back (the transcript is not re-streamed, but the
+        model remembers all of it). Driven by the UI's launch-time Resume button; the
+        button waits for the ('resumed'/'resume_failed') outcome to restyle itself."""
+        sid = str(session_id)
+        await self._close()
+        self._saw_stream = False
+        self._resume_session_id = sid
+        await self._open()          # a failed resume falls back to a fresh session there
+        if self._client is not None and self._session_id == sid:
+            self.ui.put(("session", sid))
+            self.ui.put(("resumed", None))
+        else:
+            self.ui.put(("resume_failed", None))
+        self.ui.put(("status", ""))
+
+    def _set_session(self, sid):
+        """Track the CLI's id for the current conversation (init/result messages carry
+        it) and tell the UI, which persists it per completed turn — that record is what
+        the next launch's Resume offer and _reconnect's context preservation run on."""
+        if not sid:
+            return
+        sid = str(sid)
+        if sid != self._session_id:
+            self._session_id = sid
+            self.ui.put(("session", sid))
+
     async def _open(self):
+        """Stand up a client. When a resume id is pending (Resume button, reconnect), a
+        failed resume-connect falls back to ONE fresh attempt — a vanished session file
+        must degrade to a fresh conversation, never to 'can't connect at all'."""
+        resuming = bool(self._resume_session_id)
+        ok = await self._open_once(quiet=resuming)
+        if ok:
+            if resuming:
+                # The conversation continues under this id until the CLI's init/result
+                # messages report the continuation id (see _set_session).
+                self._session_id = self._resume_session_id
+            self._resume_session_id = None
+            return
+        if resuming:
+            self._resume_session_id = None
+            self.ui.put(("system", "⚠ Couldn't resume the previous conversation (its "
+                                   "session may have been cleaned up) — starting fresh."))
+            await self._open_once()
+
+    async def _open_once(self, quiet=False):
         try:
             self._client = ClaudeSDKClient(options=self._make_options())
             self._bypass_capable = (self._permission_mode == "bypassPermissions")
@@ -402,8 +477,14 @@ class ClaudeWorker(threading.Thread):
                 self._loop.create_task(self._emit_usage())
             except Exception:
                 pass
-        except BaseException as e:   # incl. CancelledError — _open must never propagate
+            return True
+        except BaseException as e:   # incl. CancelledError — _open_once must never propagate
             self._client = None
+            if quiet:
+                # A resume attempt: _open announces the fallback itself; the raw error
+                # would only alarm (the retry right after it usually succeeds).
+                dbg("open_quiet_fail", f"{type(e).__name__}: {e}")
+                return False
             if isinstance(e, (asyncio.TimeoutError, TimeoutError)):
                 self.ui.put(("error",
                     f"Connecting to Claude timed out after {CONNECT_TIMEOUT}s. The next "
@@ -418,6 +499,7 @@ class ClaudeWorker(threading.Thread):
                     "Is the `claude` CLI installed and logged in? Run `claude --version` "
                     "in a terminal; if it's missing, run setup.cmd (or `irm "
                     "https://claude.ai/install.ps1 | iex`), then `claude` to /login."))
+            return False
 
     @staticmethod
     def _model_family(m):
@@ -801,6 +883,7 @@ class ClaudeWorker(threading.Thread):
                     elif isinstance(blk, ToolUseBlock):
                         self.ui.put(("tool", (blk.name, blk.input)))
         elif isinstance(msg, ResultMessage):
+            self._set_session(getattr(msg, "session_id", None))
             is_err = getattr(msg, "is_error", False)
             subtype = getattr(msg, "subtype", None)
             detail = getattr(msg, "result", None)
@@ -812,3 +895,12 @@ class ClaudeWorker(threading.Thread):
             self.ui.put(("result", {"cost": getattr(msg, "total_cost_usd", None),
                                     "is_error": is_err, "subtype": subtype,
                                     "result": detail, "stop_reason": stop_reason}))
+        elif type(msg).__name__ == "SystemMessage":
+            # The init system message carries the session id the moment the first turn
+            # streams — earlier than the result, so a turn interrupted mid-stream still
+            # leaves the conversation resumable. Matched by class name like the compact
+            # helpers, so this never depends on which types the installed SDK exports.
+            if getattr(msg, "subtype", None) == "init":
+                data = getattr(msg, "data", None)
+                if isinstance(data, dict):
+                    self._set_session(data.get("session_id"))

--- a/worker.py
+++ b/worker.py
@@ -105,6 +105,21 @@ class ClaudeWorker(threading.Thread):
         # When set, the next _open() launches the CLI with --resume <id> (consumed
         # there; a failed resume falls back to ONE fresh attempt).
         self._resume_session_id = None
+        # Set True by _open ONLY when a --resume connect genuinely carried the session
+        # (kwarg supported + connect succeeded). _do_resume reports "resumed" off this,
+        # not off _session_id, which _open force-sets optimistically before any stream
+        # confirms it. Cleared/False on any fresh-session fallback.
+        self._resume_ok = False
+        # The id we asked the CLI to --resume, held until the first streamed init/result
+        # reveals the id the CLI ACTUALLY loaded. If they differ, the CLI accepted
+        # --resume but silently started fresh (a pruned session, or an older CLI that
+        # warns-and-continues instead of raising) → _set_session flags it as resume_lost,
+        # so an optimistic "resumed" can't stand while the context is really gone.
+        self._resume_expected = None
+        # Kwargs _make_options had to strip because the installed SDK is too old for them
+        # (see the droppable list). Recorded so _open can tell "connected WITH --resume"
+        # from "connected fresh because this SDK has no --resume".
+        self._last_dropped = []
 
     def ask(self, text: str, image_paths=None):
         self.req.put(("ask", (text, list(image_paths or []))))
@@ -281,6 +296,7 @@ class ClaudeWorker(threading.Thread):
         # loads (with reduced features) instead of failing to construct options at all.
         droppable = ["strict_mcp_config", "max_buffer_size", "can_use_tool",
                      "include_partial_messages", "skills", "disallowed_tools", "resume"]
+        self._last_dropped = []
         while True:
             try:
                 return ClaudeAgentOptions(**opts)
@@ -290,6 +306,7 @@ class ClaudeWorker(threading.Thread):
                     victim = next((k for k in droppable if k in opts), None)
                 if victim is None:
                     raise
+                self._last_dropped.append(victim)
                 opts.pop(victim, None)
 
     def run(self):
@@ -359,7 +376,8 @@ class ClaudeWorker(threading.Thread):
                     self._saw_stream = False
                     self._session_id = None          # Clear = deliberate discard: neither a
                     self._resume_session_id = None   # reconnect nor the next launch may
-                                                     # resurrect the wiped conversation
+                    self._resume_expected = None     # resurrect the wiped conversation (and
+                                                     # no stale expectation fires resume_lost)
                     await self._open()
                     self.ui.put(("reset_done", None))
                 elif kind == "ask":
@@ -408,6 +426,7 @@ class ClaudeWorker(threading.Thread):
             pass
         self._saw_stream = False
         self._resume_session_id = sid
+        self._resume_expected = sid   # same silent-fresh backstop as the Resume button
         await self._open()
 
     async def _do_resume(self, session_id):
@@ -419,11 +438,18 @@ class ClaudeWorker(threading.Thread):
         await self._close()
         self._saw_stream = False
         self._resume_session_id = sid
-        await self._open()          # a failed resume falls back to a fresh session there
-        if self._client is not None and self._session_id == sid:
+        self._resume_expected = sid   # verified against the CLI's first streamed id below
+        await self._open()            # a failed resume falls back to a fresh session there
+        # Report off _resume_ok, not `_session_id == sid`: _open force-sets _session_id to
+        # the pending id on any successful connect, so that comparison always held and
+        # validated nothing. _resume_ok is True only when --resume was actually honoured;
+        # the streamed-init check in _set_session then catches a CLI that accepted --resume
+        # but silently started fresh (→ resume_lost).
+        if self._client is not None and self._resume_ok:
             self.ui.put(("session", sid))
             self.ui.put(("resumed", None))
         else:
+            self._resume_expected = None
             self.ui.put(("resume_failed", None))
         self.ui.put(("status", ""))
 
@@ -434,6 +460,15 @@ class ClaudeWorker(threading.Thread):
         if not sid:
             return
         sid = str(sid)
+        expected, self._resume_expected = self._resume_expected, None
+        if expected is not None and sid != expected:
+            # We launched with --resume <expected>, but the CLI's FIRST streamed message
+            # reports a different id: it accepted --resume yet silently started a fresh
+            # conversation (a pruned session, or an older CLI that warns-and-continues
+            # rather than raising). The earlier optimistic "resumed" is therefore wrong —
+            # the old context is gone. Tell the UI so it can correct the claim; the id
+            # update just below then makes this fresh session the resumable one.
+            self.ui.put(("resume_lost", None))
         if sid != self._session_id:
             self._session_id = sid
             self.ui.put(("session", sid))
@@ -443,16 +478,34 @@ class ClaudeWorker(threading.Thread):
         failed resume-connect falls back to ONE fresh attempt — a vanished session file
         must degrade to a fresh conversation, never to 'can't connect at all'."""
         resuming = bool(self._resume_session_id)
+        if resuming:
+            self._resume_ok = False          # set True only on a genuine --resume connect
         ok = await self._open_once(quiet=resuming)
         if ok:
             if resuming:
+                if "resume" in self._last_dropped:
+                    # The installed SDK is too old for the `resume` kwarg: _make_options
+                    # stripped it, so this "successful" connect is a FRESH session, not
+                    # the resumed one. Report it as a resume failure — otherwise the
+                    # caller announces "resumed" for a conversation that never loaded.
+                    self._resume_session_id = None
+                    self._resume_expected = None
+                    self.ui.put(("system",
+                        "⚠ Your claude-agent-sdk is too old to resume a conversation "
+                        "(no --resume support) — started a fresh session. Update it "
+                        "(pip install --upgrade claude-agent-sdk) to keep conversations "
+                        "across restarts."))
+                    return
                 # The conversation continues under this id until the CLI's init/result
-                # messages report the continuation id (see _set_session).
+                # messages report the continuation id (see _set_session), which also
+                # backstops the case where the CLI silently started fresh.
                 self._session_id = self._resume_session_id
+                self._resume_ok = True
             self._resume_session_id = None
             return
         if resuming:
             self._resume_session_id = None
+            self._resume_expected = None
             self.ui.put(("system", "⚠ Couldn't resume the previous conversation (its "
                                    "session may have been cleaned up) — starting fresh."))
             await self._open_once()


### PR DESCRIPTION
## What

Two related fixes to the same underlying loss-of-context problem, built on tracking the CLI's session id from the stream:

1. **One-click resume on launch.** The overlay persists the current conversation's session id on every completed turn (in the same per-machine `state.json` as the toggles). The next launch shows a **↺ Resume last conversation** button in the chat (same embedded-canvas pattern as the CLI-update button). Click it and the worker relaunches the client with `--resume` — the transcript isn't replayed, but Claude remembers everything, so you just keep going. This closes the loop on the overlay's own update flow, which asks the user to restart and used to cost them their conversation.

2. **Transport drops no longer lose the conversation.** The `↻ Connection hiccup` recovery path reconnected with a *fresh* session — silently discarding all context. It now reconnects with `--resume` into the same conversation; only a failed resume falls back to fresh (announced as such).

## Guard rails

- The offer only appears for a session from the **same working directory** (the CLI stores sessions per directory), younger than `RESUME_OFFER_MAX_AGE` (7 days). `RESUME_OFFER = False` / `CLAUDE_OVERLAY_RESUME_OFFER=0` disables it.
- **Clear wipes the record** (worker-side ids too) — a deliberately discarded conversation is never offered back, and a reconnect right after Clear can't resurrect it.
- Once a new conversation starts (first send), the button goes **stale** — clicking it then would silently discard the messages just exchanged.
- A resume against a vanished session degrades to **one** fresh connect attempt with an in-chat notice — it can never leave the overlay unable to connect at all. The resume error itself is kept quiet (debug log only); the fallback is what the user sees.

## Permission note (per CONTRIBUTING)

No permission behavior changes: a resumed session is launched in the overlay's *current* permission mode, exactly like a reset — the Read-only toggle, `_bypass_capable` re-derivation, and the plan-mode deny guard all apply unchanged.

## Verified live (CLI 2.1.x / SDK 0.2.119)

- Resume restores context: a fact planted in session A is recalled after disconnect + `--resume` (and the resumed session keeps the **same session id**, which the bookkeeping relies on).
- Resume with an unknown id fails the connect with `ProcessError` (`No conversation found with session ID: …`) — the exact path the quiet-fallback handles.

## Tests

- 14 worker tests: id capture from real SDK `SystemMessage(init)` / `ResultMessage`, dedup + emit-once, `--resume` passthrough in `_make_options` (with `resume` added to the old-SDK droppable list), `_reconnect` carrying the live id, `_do_resume` outcome signalling (resumed / resume_failed / fallback).
- 16 UI tests (`test_ui_resume.py`): offer gating (missing/foreign-cwd/too-old/malformed records), click routing + busy/double-click guards, restyling on `resumed`/`resume_failed`, staling on first send, per-turn persistence, Clear wiping the record.
- Full suite: 362 passed. (`test_copy_btn_puts_text_on_clipboard` fails on my machine on unmodified `main` too — another app owns the clipboard — unrelated.)

Note: the CHANGELOG gets an **Unreleased** section, which will conflict trivially with #4 if both land — whichever merges second just needs the two bullets folded together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)