### PR TITLE
Put the allowance on the mark, and let the row hold still

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
         run: python -m pip install -r requirements-dev.txt
 
       - name: Byte-compile all modules
-        run: python -m py_compile config.py debuglog.py win32utils.py worker.py claude_overlay.py crashreport.py preflight.py modelresolve.py cliupdate.py authstate.py
+        run: python -m py_compile config.py debuglog.py win32utils.py worker.py claude_overlay.py crashreport.py preflight.py modelresolve.py cliupdate.py authstate.py usage.py
 
       - name: Import smoke test (no window, no connect)
         run: python -c "import claude_overlay; print('import OK', claude_overlay.__version__)"

--- a/README.md
+++ b/README.md
@@ -358,9 +358,10 @@ script here *scans* that folder and uses whatever runs, no matter how it got the
 | &nbsp;&nbsp;• Show / hide in screen shares | **⚙ → Shareable** (visible to Teams/Zoom/OBS; off = private, the default) |
 | &nbsp;&nbsp;• Lock Claude read-only | **⚙ → Read-only** ("plan" mode: looks and answers, changes nothing; off = the configured `PERMISSION_MODE`) |
 | Switch model | click the **statusline** (`model ▾`) |
-| See how much allowance is left | the statusline's `quota 78% (5h) · resets 19:40` — the CLI's own rate-limit reading, amber as you approach it and red once it's gone; it speaks up once per transition, and a message refused for allowance is put back in the box rather than lost |
+| See how much allowance is left | **two arcs around the ✻ mark** — the inner one is the 5-hour window, the outer one is weekly. Both are drawn, always: the 5-hour window is the one that ends the session you're in, and it spends most of its life sitting below the weekly number, so showing only whichever is furthest along would hide it for exactly as long as it matters. Filled in from your account the moment the overlay opens, so it's there **before** you send anything, and refreshed every minute while it sits idle; amber as you approach a limit, red once it's gone. It speaks up once per transition, and a message refused for allowance is put back in the box rather than lost |
+| See the exact numbers | **hover the ✻ mark** — a small panel drops under it with both allowance windows, their reset times, and the context headroom in turns (extrapolated from what recent ones cost). No unlabelled gauge explains itself; this is how you ask it |
 | Retry when the allowance returns | a refused message offers **⏱ Send it automatically at &lt;time&gt;** — opt-in, one click, and it stands down the moment you type something else, send by hand, or Clear |
-| See how much context is left | the same slot shows `context 72% · ~8 turns` once context passes 70% — turns extrapolated from what recent ones cost. Below that the allowance is the number that matters, so context stays out of the way |
+| See how much context is left | the statusline's `context 72%` — always there, and it never reflows: the allowance moved to the mark, so nothing competes with it for the slot. A note at 70% and again at 85% says when compacting is worth it |
 | Zoom text in / out | **Ctrl +** / **Ctrl −** (or **Ctrl + mouse-wheel**); **Ctrl 0** resets |
 | New conversation | **Clear** |
 | Compact the conversation (free up context) | **Compact** — summarizes older turns, keeps going |
@@ -502,6 +503,17 @@ toggle's last state is remembered per-machine, and a launch says so in-chat when
 the remembered choice differs from the configured default. (`"acceptEdits"` / `"default"` are
 of limited use here: a GUI with no terminal has nowhere to show a permission prompt,
 so the overlay auto-answers them — see `worker._allow_tool`.)
+
+**One thing the overlay reads that it previously didn't:** to show your plan allowance
+before you've sent anything, it reads the OAuth access token the `claude` CLI already
+stores in `~/.claude/.credentials.json` and sends it, once a minute, in a single
+`GET https://api.anthropic.com/api/oauth/usage` — the same endpoint the CLI's own
+`/usage` screen reads. That token is never stored by the overlay, never written to the
+debug log, and never sent anywhere but `api.anthropic.com`; the request is a GET, so it
+can't spend, change or send anything, and no token is ever refreshed (that stays the
+CLI's job). Accounts authenticating another way — API key, Bedrock, Vertex, a gateway —
+are skipped entirely, and every failure just leaves the gauge as it was. It's all in
+[`usage.py`](usage.py), which is short and commented for exactly this reason.
 
 ## Contributing
 

--- a/claude_overlay.py
+++ b/claude_overlay.py
@@ -124,6 +124,7 @@ try:
     from worker import ClaudeWorker
     import authstate
     import sessions
+    import usage
 except Exception as _e:
     _report_import_failure(_e)
 
@@ -365,6 +366,72 @@ _QUOTA_WINDOWS = {"five_hour": "5h", "seven_day": "week", "seven_day_opus": "wee
                   "seven_day_sonnet": "week/sonnet", "overage": "overage"}
 _QUOTA_HOT = 0.90                 # colour by the number shown, even if the CLI still says
                                   # "allowed" — a grey 94% reads as nothing being wrong
+_QUOTA_WARN = 0.75                # the ring's amber step. The text gauge can wait for the
+                                  # CLI's own "allowed_warning" because it prints a number you
+                                  # read; an arc has no number, so it has to earn attention
+                                  # before it is nearly spent or it says nothing until too late.
+
+
+def _mix(a, b, t):
+    """Blend two #rrggbb colours, t of the way from a to b."""
+    x, y = (int(a[i:i + 2], 16) for i in (1, 3, 5)), (int(b[i:i + 2], 16) for i in (1, 3, 5))
+    return "#%02X%02X%02X" % tuple(round(p + (q - p) * t) for p, q in zip(x, y))
+
+
+def _contrast(a, b):
+    """WCAG contrast ratio between two #rrggbb colours — used to prove a gauge is visible
+    rather than to assume it, after a track at 1.2:1 shipped as a blank mark."""
+    def lum(h):
+        c = [int(h[i:i + 2], 16) / 255 for i in (1, 3, 5)]
+        c = [v / 12.92 if v <= 0.03928 else ((v + 0.055) / 1.055) ** 2.4 for v in c]
+        return 0.2126 * c[0] + 0.7152 * c[1] + 0.0722 * c[2]
+    p, q = lum(a), lum(b)
+    return (max(p, q) + 0.05) / (min(p, q) + 0.05)
+
+
+# Radii and stroke widths as fractions of a 32px mark, the size they were tuned at; the mark
+# is drawn at _MARK_PX and these scale with it. Inner track is the 5-hour window and is the
+# thicker of the two — it is the one that ends the session you are sitting in.
+_RING_GEOM = (("five_hour", 10.5 / 32, 3 / 32), ("week", 14.5 / 32, 2 / 32))
+_SPARK_R = 5.75 / 32           # small enough to leave clear air inside the 5h track:
+                               # when that arc goes amber it is T["accent"], the same
+                               # colour as the mark, and touching arc and mark merge
+_RING_SS = 4                      # supersample factor, then downsample: Tk's create_arc has
+                                  # no antialiasing on Windows and a 3px arc on a 36px circle
+                                  # comes out a visible staircase
+_MARK_PX = 36                     # two legible arcs plus a readable ✻ need this much room;
+                                  # the titlebar is 44px tall, so this is the largest that fits
+
+
+def _binding_window(windows):
+    """The one window that earns the statusline's single text slot: whichever is furthest
+    along, because the binding constraint is the limit you reach first and the rest are noise
+    until they overtake it. Ties go to five_hour — at equal percentages it is the one that can
+    end the session you are sitting in right now.
+
+    This rule used to live in usage.reading(), which applied it before the UI ever saw the
+    data. That was the wrong altitude twice over: it is a decision about what to SHOW, and
+    collapsing to it in the data layer threw away the other windows — including the 5-hour one
+    the ring now draws, which by definition is the one being discarded during the whole early
+    stretch when it sits below the weekly number. Reporting is usage.py's job; choosing is ours.
+
+    Takes windows keyed by name (utilization already 0-1) and returns one of them with its
+    name folded in, or None. The result deliberately carries no `status`: a polled reading has
+    none, so _gauge_color goes on colouring by the number, which is what it already did.
+    """
+    best = None
+    for name in _QUOTA_WINDOWS:
+        w = (windows or {}).get(name)
+        if not isinstance(w, dict):
+            continue
+        u = w.get("utilization")
+        if isinstance(u, bool) or not isinstance(u, (int, float)):
+            continue
+        if best is None or u > best[1]:
+            best = (name, float(u))
+    return dict(windows[best[0]], window=best[0]) if best else None
+
+
 _RETRY_POLL_MS = 60_000           # how often an armed retry checks the clock. A single long
                                   # after() would be the obvious choice and the wrong one: Tk
                                   # timers don't run while the machine sleeps, so a laptop
@@ -452,7 +519,13 @@ class Overlay:
                                         # conversation and after a compaction wins the room back
         self._ctx_sample_due = False    # a turn ended; the next usage refresh is its data point
         self._quota = None              # last rate-limit reading the CLI reported (see "quota")
+        self._quota_polled = None       # last reading usage.py fetched itself (see "quota_poll").
+                                        # Kept apart from _quota, not merged into it: this one is
+                                        # fresher and so wins the DISPLAY, while everything that
+                                        # speaks or sends still reads the CLI's own event above.
         self._quota_said = None         # status already announced, so each transition speaks once
+        self._ring_explained = False    # the ring names itself once, when there is finally
+                                        # something to point at (see _maybe_explain_ring)
         self._last_sent = None          # (text, images) of the last message handed to the worker,
                                         # so a refusal that never reached Claude can give it back
         self._retry = None              # {"at", "text", "armed"} — a refused message waiting for
@@ -638,7 +711,18 @@ class Overlay:
         self.root.after(220, self._install_taskbar_button)
         self.root.after(1200, self._check_for_update)
         self.root.after(1500, self._check_cli_update)
+        self._usage_poll = usage.Poller(self.ui_q)
+        self._start_usage_poll()
         self._start_hang_watchdog()    # diagnostic: dumps all-thread stacks if the UI pump stalls
+
+    def _start_usage_poll(self):
+        """Start the allowance poll, so the gauge has a number before the first message.
+
+        Its own method purely so the test suite can neuter it on the Overlay it builds
+        (no network, and this machine's real token never read) WITHOUT patching
+        usage.Poller itself — the session-wide Overlay fixture would otherwise leave the
+        class stubbed for every later unit test of that class."""
+        self._usage_poll.start()
 
     def _start_hang_watchdog(self):
         """Diagnostic (active only when CLAUDE_OVERLAY_DEBUG_LOG is set): a daemon thread that,
@@ -952,10 +1036,28 @@ class Overlay:
         self.titlebar = bar
         bar.pack_propagate(False)
         self._bind_drag(bar)
-        sz = self.px(24)
+        sz = self.px(_MARK_PX)
         mark = tk.Canvas(bar, width=sz, height=sz, bg=T["bg"], highlightthickness=0)
-        mark.pack(side="left", padx=(self.px(14), self.px(7)))
-        self._draw_spark(mark, sz / 2, sz / 2, self.px(9))
+        mark.pack(side="left", padx=(self.px(10), self.px(7)))
+        # The whole mark — allowance arcs AND the ✻ — is one supersampled image rather than
+        # Tk canvas primitives, so every curve is antialiased. See _paint_quota_ring.
+        self._mark, self._mark_sz = mark, sz
+        self._paint_quota_ring()
+        # The ring can carry the numbers but not their name. A pointer cursor says it answers
+        # to something, and <Enter> is where the answer arrives — see _quota_hover_text.
+        mark.configure(cursor="hand2")
+        mark.bind("<Enter>", self._mark_enter, add="+")
+        mark.bind("<Leave>", self._mark_leave, add="+")
+        # Deliberately a child of root rather than a Toplevel. The capture exclusion that keeps
+        # the overlay out of screen shares - and out of the screenshots we send Claude - is set
+        # on the root HWND (see _apply_share_visibility) and a new top-level window does not
+        # inherit it: the panel would show up in a Teams share while the overlay itself did not,
+        # and would land inside our own grabs, because capture() skips its withdraw dance
+        # whenever the exclusion is active. A placed child inherits all of that for nothing.
+        self._usage_panel = tk.Label(self.root, text="", bg=T["tool_bg"], fg=T["text"],
+                                     font=self.f_mono, justify="left", anchor="w",
+                                     padx=self.px(10), pady=self.px(8),
+                                     highlightthickness=1, highlightbackground=T["border"])
         self._bind_drag(mark)
         # The title doubles as the rename target: click it (without dragging) to edit this
         # overlay's name; dragging it still moves the window (moved-detection, like the orb).
@@ -1722,16 +1824,6 @@ class Overlay:
             self.toggle_collapse()   # click the bubble → expand
 
     # ── small widgets ──
-    def _draw_spark(self, c, cx, cy, r):
-        import math
-        for i in range(12):
-            a = math.pi * i / 6
-            r1 = r if i % 2 == 0 else r * 0.5
-            c.create_line(cx, cy, cx + r1 * math.cos(a), cy + r1 * math.sin(a),
-                          fill=T["accent"], width=max(2, self.px(2)), capstyle="round")
-        d = max(2, self.px(2))
-        c.create_oval(cx - d, cy - d, cx + d, cy + d, fill=T["accent"], outline="")
-
     def _title_btn(self, parent, text, cmd):
         b = tk.Label(parent, text=text, bg=T["bg"], fg=T["muted"], font=self.f_small,
                      cursor="hand2", width=3)
@@ -4459,42 +4551,226 @@ class Overlay:
         # version goes last so it clips first if the window is narrow; ⬆ flags an update
         ver = f"v{__version__}" + ("  ⬆" if self._update_available else "")
         self.statusline.configure(text=f"{self._model or 'Claude'} ▾", fg=T["muted"])
-        self.ctx_lbl.configure(text=f"·   {self._gauge_text()}", fg=self._gauge_color())
+        self.ctx_lbl.configure(text=f"·   {self._gauge_text()}", fg=self._ctx_color())
         self.ver_lbl.configure(text=f"·   {ver}", fg=T["muted"])
+        self._paint_quota_ring()
 
     # ── the middle of the statusline ──
     def _ctx_text(self):
-        """Context as a percentage, plus the headroom in turns once there's a slope to read."""
+        """Context as a percentage, and nothing else.
+
+        The headroom in turns used to be appended here, which meant the row grew a second
+        clause the moment a burn rate could be read and lost it again after a compaction. The
+        one strip of chrome that should hold still was reflowing while you looked at it. The
+        figure is not gone - _usage_panel_text carries it, one hover away, and the end-of-turn
+        warning still speaks it."""
         p = f"{self._ctx_pct:.0f}%" if isinstance(self._ctx_pct, (int, float)) else "—"
-        left = self._ctx_turns_left()
-        if left is not None:
-            p += f" · ~{left} turn{'' if left == 1 else 's'}"
         return f"context {p}"
 
     def _gauge_text(self):
-        """What the gauge says. The allowance owns the slot whenever the CLI has reported
-        one, because it's the limit that ends sessions; context joins it only once context is
-        over its own warning line and has become the more urgent of the two. Before any
-        rate-limit event arrives (an older CLI, or a session that hasn't transitioned yet)
-        the slot falls back to context, which is better than an empty gauge."""
-        q = self._quota or {}
-        u = q.get("utilization")
-        if not isinstance(u, (int, float)):
-            return self._ctx_text()
-        win = _QUOTA_WINDOWS.get(q.get("window"))
-        bits = [f"quota {u * 100:.0f}%" + (f" ({win})" if win else "")]
-        resets = self._quota_resets_text()
-        if resets:
-            bits.append(resets)
-        if isinstance(self._ctx_pct, (int, float)) and self._ctx_pct >= _CTX_WARN_PCT:
-            bits.append(self._ctx_text())
-        return " · ".join(bits)
+        """What the row carries when the mark is not being hovered: context.
 
-    def _quota_resets_text(self):
+        The allowance used to own this slot, with context demoted to a fallback and allowed
+        back only once it was over its own warning line - two percentages competing for one
+        place. The allowance lives on the ring now, and printing it here as well would be the
+        same number twice; on a narrow overlay that duplication is what pushed the version off
+        the end. Context is NOT duplicated by the ring: the ring is the plan allowance, context
+        is the size of THIS conversation, and the two answer different questions. So context
+        simply keeps the slot, and the competition this method used to arbitrate is gone.
+        """
+        return self._ctx_text()
+
+    def _usage_panel_text(self):
+        """Everything about usage, in one aligned block, for the panel the mark opens.
+
+        No unlabelled gauge explains itself. What makes one learnable is being able to
+        interrogate it, and the answer belongs where the asking happened - beside the mark,
+        not down in a status row that then reflows under the cursor. Both allowance windows
+        and context sit here together because they are the same question asked three ways, and
+        because context's turns figure had to leave the row to stop it moving."""
+        rows = []
+        wins = self._ring_windows()
+        for key, label in (("five_hour", "5h"), ("week", "week")):
+            u = (wins.get(key) or {}).get("utilization")
+            if isinstance(u, bool) or not isinstance(u, (int, float)):
+                continue
+            rows.append((label, f"{u * 100:.0f}%", self._quota_resets_text(wins[key])))
+        if not rows:
+            rows.append(("allowance", "—", "no reading yet"))
+        p = self._ctx_pct
+        if isinstance(p, (int, float)):
+            left = self._ctx_turns_left()
+            rows.append(("context", f"{p:.0f}%",
+                         f"~{left} turn{'' if left == 1 else 's'} left" if left is not None else ""))
+        w = max(len(r[0]) for r in rows)
+        return "\n".join(f"{a.ljust(w)}   {b:>4}   {c}".rstrip() for a, b, c in rows)
+
+    def _mark_enter(self, _e=None):
+        self._usage_panel.configure(text=self._usage_panel_text())
+        # Just under the titlebar, left-aligned with the mark it belongs to.
+        self._usage_panel.place(x=self.px(10), y=self.px(42))
+        self._usage_panel.lift()
+
+    def _mark_leave(self, _e=None):
+        self._usage_panel.place_forget()
+
+    def _maybe_explain_ring(self):
+        """Name the ring once, the first time there is something to point at.
+
+        A first-time reader has no way to guess that two arcs around a logo are a plan
+        allowance — the shape can carry the numbers but not their meaning. One sentence, said
+        once, is the only thing that closes that gap; after that the hover carries it."""
+        if self._ring_explained or not self._ring_arcs():
+            return
+        self._ring_explained = True
+        self.add_sys("◔ The ring on ✻ is your plan allowance — the inner arc is the 5-hour "
+                     "window, the outer one is weekly. Hover the mark for the numbers.")
+
+    def _gauge_quota(self):
+        """The freshest allowance reading, for DISPLAY only.
+
+        usage.py polls every minute; the CLI speaks only when its status transitions, so its
+        copy can be hours old — and while the overlay sits idle, hours old is exactly when the
+        number is worth looking at. So the poll wins the gauge whenever it has one.
+
+        It wins nothing else. _announce_quota and _offer_retry read self._quota directly and
+        deliberately: the polled reading carries no status (usage.py won't invent one from the
+        endpoint's severity vocabulary), and a warning that speaks, or a retry that puts a
+        message on the wire hours later, must come from the CLI's own event or not at all."""
+        w = (self._quota_polled or {}).get("windows")
+        if isinstance(w, dict) and w:
+            return _binding_window(w) or {}
+        return self._quota or {}
+
+    def _quota_windows(self):
+        """Every allowance window we can place on the ring, keyed by name.
+
+        The poll carries all of them. The CLI's own event carries exactly one, and only
+        sometimes names it — an unnamed one is DROPPED rather than parked on whichever track
+        is handy, because putting a weekly reading on the 5-hour arc would be a lie the user
+        has no way to see through. The statusline text still prints that number, so staying
+        silent here costs nothing.
+        """
+        w = (self._quota_polled or {}).get("windows")
+        if isinstance(w, dict) and w:
+            return w
+        q = self._quota or {}
+        u, name = q.get("utilization"), q.get("window")
+        if name in _QUOTA_WINDOWS and isinstance(u, (int, float)) and not isinstance(u, bool):
+            return {name: {"utilization": float(u), "resets_at": q.get("resets_at")}}
+        return {}
+
+    def _ring_color(self, u, quiet):
+        """Recessive until it isn't. An arc carries no number, so colour is the only channel
+        it has for urgency — hence its own amber step rather than waiting for the CLI's."""
+        if u >= _QUOTA_HOT:
+            return T["err"]
+        if u >= _QUOTA_WARN:
+            return T["accent"]
+        return quiet
+
+    def _ring_track(self):
+        """The empty part of a gauge, in a tone you can actually see.
+
+        The first cut used T["border"], which is 1.2:1 against the surface — exactly right for
+        a hairline between two panels and completely invisible as a track, so a fresh overlay
+        with no reading yet drew a mark that looked untouched. _contrast pins the replacement
+        rather than trusting the eye that missed it the first time."""
+        return _mix(T["bg"], T["faint"], 0.70)   # 1.8:1 light, 2.1:1 dark — seen, not shouted
+
+    def _ring_windows(self):
+        """The two tracks, each resolved to the one window it stands for. Shared by the ring
+        and by the hover text so a number and its label can never come from different windows."""
+        wins = self._quota_windows()
+        return {"five_hour": wins.get("five_hour"),
+                "week": _binding_window({k: v for k, v in wins.items() if k != "five_hour"})}
+
+    def _ring_arcs(self):
+        """What each track should show: {track: (fraction, colour)}, tracks with nothing to
+        say left out. Kept separate from the drawing so the numbers and colours can be tested
+        without decoding a bitmap."""
+        out = {}
+        for key, w in self._ring_windows().items():
+            u = (w or {}).get("utilization")
+            if isinstance(u, bool) or not isinstance(u, (int, float)) or u <= 0.005:
+                continue           # a hairline at 0% would read as "something is used"
+            out[key] = (min(1.0, float(u)), self._ring_color(u, T["muted"]))
+        return out
+
+    def _paint_quota_ring(self):
+        """The ✻ mark, ringed by two allowance gauges: the 5-hour window inside, the weekly
+        one outside.
+
+        WHY TWO, AND WHY HERE. The status row had one slot and filled it with whichever window
+        was furthest along, labelled "(5h)" or "(week)". That works as text because the text
+        says which window it is describing — but the row was also carrying the model name, the
+        reset time and the version, and on a narrow overlay the version was being clipped.
+        Moving the gauge onto the mark buys the row back; the catch is that an arc cannot carry
+        the label, so a single arc that silently changed meaning would be strictly worse than
+        the text it replaced. Two fixed tracks answer both at once: position IS the label, and
+        the thicker inner one is the window that ends the session you are sitting in.
+
+        Two arcs are also the honest reading of the data. The weekly window climbs slowly in
+        the background; the 5-hour one can go from a tenth to spent in an afternoon. Ranking
+        them by magnitude hid the 5-hour window for exactly as long as it sat below the weekly
+        number — which is where it is every time you sit down to work. Both are the same unit
+        (share of an allowance) on the same 0-1 scale, so drawing them together is one scale,
+        not two. The sweep runs clockwise from 12 o'clock, the direction a clock face reads,
+        which is what a window that empties and refills on a timer actually is.
+
+        WHY AN IMAGE. Tk's create_arc is not antialiased on Windows, and a 3px stroke on a 36px
+        circle comes out a visible staircase — the first cut of this was drawn with canvas
+        primitives and was unreadable at real size. Everything is rendered at _RING_SS× into
+        one PIL image, downsampled, and placed as a single canvas item, so every curve
+        (including the ✻ itself) is smooth. The photo is kept on the instance because Tk holds
+        only a weak claim on a PhotoImage — drop the Python reference and the mark goes blank.
+        """
+        c = getattr(self, "_mark", None)
+        if c is None:              # a repaint can land before the titlebar is built
+            return
+        sz = self._mark_sz
+        S = sz * _RING_SS
+        im = Image.new("RGB", (S, S), T["bg"])
+        d = ImageDraw.Draw(im)
+        arcs, track = self._ring_arcs(), self._ring_track()
+        for key, rf, wf in _RING_GEOM:
+            r, lw = S * rf, max(1, round(S * wf))
+            box = [S / 2 - r, S / 2 - r, S / 2 + r, S / 2 + r]
+            # The empty track is always drawn: an arc with nothing behind it reads as a
+            # fragment of something rather than as "this much of that".
+            d.arc(box, 0, 360, fill=track, width=lw)
+            a = arcs.get(key)
+            if a:
+                d.arc(box, -90, -90 + 360 * a[0], fill=a[1], width=lw)
+        self._draw_spark_pil(d, S)
+        self._ring_photo = ImageTk.PhotoImage(im.resize((sz, sz), Image.LANCZOS))
+        c.delete("ring")
+        c.create_image(sz / 2, sz / 2, image=self._ring_photo, tags="ring")
+
+    def _draw_spark_pil(self, d, S):
+        """The ✻ at the centre of the mark, into the same supersampled image as the rings.
+        Round tips are ellipses because PIL has no cap style; at _RING_SS× they land as the
+        same shape Tk's capstyle="round" used to give."""
+        import math
+        cx = cy = S / 2
+        r, w = S * _SPARK_R, max(1, round(S * 2 / 32))
+        for i in range(12):
+            a = math.pi * i / 6
+            r1 = r if i % 2 == 0 else r * 0.5
+            x, y = cx + r1 * math.cos(a), cy + r1 * math.sin(a)
+            d.line([cx, cy, x, y], fill=T["accent"], width=w)
+            d.ellipse([x - w / 2, y - w / 2, x + w / 2, y + w / 2], fill=T["accent"])
+
+    def _quota_resets_text(self, q):
         """When the allowance comes back, as a wall clock. A live countdown would need a timer
         redrawing a number nobody watches tick; the time you can start again is the thing you
-        actually plan around. Weekly windows can reset days out, so those name the day too."""
-        ts = (self._quota or {}).get("resets_at")
+        actually plan around. Weekly windows can reset days out, so those name the day too.
+
+        Takes the reading to describe, because its two callers want different ones: the gauge
+        shows whichever is freshest, while an announcement must quote the same event whose
+        status it is announcing — mixing them could pair "weekly allowance is used up" with
+        the 5-hour window's reset time."""
+        ts = (q or {}).get("resets_at")
         if not isinstance(ts, (int, float)) or ts <= 0:
             return ""
         try:
@@ -4504,7 +4780,10 @@ class Overlay:
             return ""
 
     def _gauge_color(self):
-        q = self._quota or {}
+        # Same reading the text came from, so colour and number can never describe different
+        # windows. A polled reading has no status, which is why _QUOTA_HOT colours by the
+        # number: an amber tier we'd have to guess at is worse than a red one we can prove.
+        q = self._gauge_quota()
         u = q.get("utilization")
         if isinstance(u, (int, float)):
             st = q.get("status")
@@ -4594,7 +4873,7 @@ class Overlay:
         if st not in ("allowed_warning", "rejected"):
             return
         win = _QUOTA_WINDOWS.get(q.get("window")) or "usage"
-        resets = self._quota_resets_text()
+        resets = self._quota_resets_text(q)
         when = f" — {resets}" if resets else ""
         if st == "rejected":
             self.add_err(f"◔ Your {win} allowance is used up{when}.")
@@ -5177,6 +5456,7 @@ class Overlay:
         elif kind == "quota":
             self._quota = payload if isinstance(payload, dict) else None
             self._refresh_statusline()
+            self._maybe_explain_ring()
             self._announce_quota()
             # The CLI saying the allowance is no longer rejected beats waiting for a clock we
             # only ever got a prediction of. A retry is only ever armed after a rejection, so
@@ -5185,6 +5465,15 @@ class Overlay:
             if r and r.get("armed") and (self._quota or {}).get("status") not in (None, "rejected"):
                 r["ready"] = True     # sticky: if we're mid-turn right now, the next tick uses it
                 self._retry_tick()
+        elif kind == "quota_poll":
+            # usage.py asked the allowance endpoint itself, so the gauge is right without
+            # having to send a message first. Display only, and on purpose: no announcement
+            # (the reading carries no status to announce) and no retry re-arm (only the CLI's
+            # own event may decide that a refused message can go back on the wire).
+            if isinstance(payload, dict):
+                self._quota_polled = payload
+                self._refresh_statusline()
+                self._maybe_explain_ring()
         elif kind == "turn_done":
             self._md_finalize()          # the turn ended → give the last line full block styling
             self._finish_turn_copy()     # then a Copy button under the reply
@@ -5352,6 +5641,11 @@ class Overlay:
             pass
         try:
             self.worker.interrupt()      # stop any in-flight turn so it can close cleanly
+        except Exception:
+            pass
+        try:
+            if getattr(self, "_usage_poll", None):
+                self._usage_poll.stop()  # daemon anyway; this just stops it waking up mid-teardown
         except Exception:
             pass
         self.worker.shutdown()

--- a/preflight.py
+++ b/preflight.py
@@ -208,7 +208,7 @@ def check():
     # with no window. Checked as files, so it reports even when nothing is importable.
     missing = [m for m in ("config.py", "worker.py", "debuglog.py", "win32utils.py",
                            "modelresolve.py", "cliupdate.py", "authstate.py",
-                           "crashreport.py")
+                           "crashreport.py", "usage.py")
                if not os.path.isfile(os.path.join(repo_dir(), m))]
     if missing:
         problems.append(Problem(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,6 +72,12 @@ def _overlay_singleton():
     mp.setattr(co, "ClaudeWorker", FakeWorker)
     mp.setattr(co.Overlay, "_register_hotkey", lambda self: None)
     mp.setattr(co.Overlay, "_check_for_update", lambda self: None)
+    # No usage-endpoint polling: the suite must not reach the network, and must not read
+    # this machine's real OAuth token. The Overlay still BUILDS its Poller, so the wiring
+    # stays under test; only the thread never starts. Patched on the Overlay rather than on
+    # usage.Poller because this fixture is session-scoped — stubbing the class here would
+    # leave it stubbed for every later unit test of the class itself.
+    mp.setattr(co.Overlay, "_start_usage_poll", lambda self: None)
     # Point the persisted-UI-state store at a throwaway path: the suite must neither
     # read this machine's real toggle state nor overwrite it from toggle tests.
     import tempfile
@@ -132,6 +138,11 @@ def _clean_overlay(ov):
     ov.overlay_name = ""
     ov._model = None
     ov._ctx_pct = None
+    ov._quota = None                    # allowance readings are per-test: a leaked one would
+    ov._quota_polled = None             # take the gauge slot away from the next test's context
+    ov._quota_said = None
+    ov._ring_explained = False          # the ring introduces itself once; a leaked flag would
+                                        # rob the next test of the introduction it is watching
     ov.pending_images = []
     ov.pending_shot = None
     ov._precaptured = None

--- a/tests/test_ui_ctx_budget.py
+++ b/tests/test_ui_ctx_budget.py
@@ -92,12 +92,12 @@ class TestStatusline:
     def test_turns_left_joins_the_percentage(self, gauge):
         for p in (10, 15, 20):
             _turn(gauge, p)
-        assert "~16 turns" in gauge.ctx_lbl.cget("text")
+        assert "~16 turns" in gauge._usage_panel_text()   # the row holds still; the panel carries it
 
     def test_one_turn_left_is_singular(self, gauge):
         for p in (50, 75):
             _turn(gauge, p)
-        assert "~1 turn" in gauge.ctx_lbl.cget("text")
+        assert "~1 turn" in gauge._usage_panel_text()
         assert "turns" not in gauge.ctx_lbl.cget("text")
 
     def test_gauge_colours_by_tier(self, gauge):

--- a/tests/test_ui_quota.py
+++ b/tests/test_ui_quota.py
@@ -37,21 +37,24 @@ def gauge(overlay):
 
 
 class TestGaugeText:
+    """The allowance moved to the ring on the mark; the row keeps context, which the ring says
+    nothing about. Hovering the mark spells the allowance back out in the row it vacated."""
 
-    def test_allowance_takes_the_slot(self, gauge):
+    def test_the_allowance_is_a_hover_away(self, gauge):
         gauge._handle("quota", _q(util=0.78))
-        assert "quota 78%" in gauge.ctx_lbl.cget("text")
+        gauge._mark_enter()
+        assert "78%" in gauge._usage_panel.cget("text")
 
     def test_the_window_is_named(self, gauge):
         # 78% of five hours and 78% of a week are very different situations.
         gauge._handle("quota", _q(util=0.78, window="five_hour"))
-        assert "(5h)" in gauge.ctx_lbl.cget("text")
+        assert "78%" in gauge._usage_panel_text().splitlines()[0]
         gauge._handle("quota", _q(util=0.78, window="seven_day"))
-        assert "(week)" in gauge.ctx_lbl.cget("text")
+        assert gauge._usage_panel_text().splitlines()[0].startswith("week")
 
     def test_reset_time_is_a_wall_clock(self, gauge):
         gauge._handle("quota", _q(resets_in=90 * 60))
-        shown = gauge.ctx_lbl.cget("text")
+        shown = gauge._usage_panel_text()
         assert "resets " + time.strftime("%H:%M", time.localtime(time.time() + 90 * 60)) in shown
 
     def test_a_distant_reset_names_the_day(self, gauge):
@@ -59,12 +62,12 @@ class TestGaugeText:
         # morning at the latest and quietly misleads by most of a week.
         gauge._handle("quota", _q(window="seven_day", resets_in=3 * 24 * 3600))
         assert time.strftime("%a", time.localtime(time.time() + 3 * 24 * 3600)) \
-            in gauge.ctx_lbl.cget("text")
+            in gauge._usage_panel_text()
 
     def test_missing_reset_time_is_simply_omitted(self, gauge):
         gauge._handle("quota", _q(resets_in=None))
-        text = gauge.ctx_lbl.cget("text")
-        assert "quota" in text and "resets" not in text
+        text = gauge._usage_panel_text()
+        assert "%" in text and "resets" not in text
 
     def test_context_falls_back_when_no_event_has_arrived(self, gauge):
         # An older CLI, or a session that hasn't transitioned yet. An empty gauge would be
@@ -78,38 +81,38 @@ class TestGaugeText:
         gauge._handle("quota", {"status": "allowed", "utilization": None})
         assert "context 31%" in gauge.ctx_lbl.cget("text")
 
-    def test_low_context_stays_out_of_the_way(self, gauge):
-        # The whole reason for the swap: two percentages compete, and for short frequent
-        # questions the context one is always the irrelevant one.
+    def test_context_no_longer_has_to_earn_the_slot(self, gauge):
+        """It used to be squeezed out by the allowance and let back in only above its own
+        warning line. With the allowance on the ring there is nothing left to compete with."""
         gauge._ctx_pct = 2
         gauge._handle("quota", _q(util=0.78))
-        assert "context" not in gauge.ctx_lbl.cget("text")
+        assert "context 2%" in gauge.ctx_lbl.cget("text")
 
-    def test_high_context_earns_the_slot_back(self, gauge):
+    def test_the_allowance_never_crowds_it_again(self, gauge):
         gauge._ctx_pct = 88
         gauge._handle("quota", _q(util=0.30))
         text = gauge.ctx_lbl.cget("text")
-        assert "quota 30%" in text and "context 88%" in text
+        assert "context 88%" in text and "quota" not in text
 
 
 class TestGaugeColour:
 
     def test_ordinary_use_is_quiet(self, gauge):
         gauge._handle("quota", _q(util=0.30))
-        assert gauge.ctx_lbl.cget("fg") == co.T["muted"]
+        assert gauge._ring_arcs()["five_hour"][1] == co.T["muted"]
 
     def test_the_cli_warning_goes_amber(self, gauge):
         gauge._handle("quota", _q(status="allowed_warning", util=0.80))
-        assert gauge.ctx_lbl.cget("fg") == co.T["accent"]
+        assert gauge._ring_arcs()["five_hour"][1] == co.T["accent"]
 
     def test_rejection_goes_red(self, gauge):
         gauge._handle("quota", _q(status="rejected", util=1.0))
-        assert gauge.ctx_lbl.cget("fg") == co.T["err"]
+        assert gauge._ring_arcs()["five_hour"][1] == co.T["err"]
 
     def test_a_high_number_goes_red_even_if_the_cli_is_still_calm(self, gauge):
         # The colour has to agree with the digits on screen: a grey 94% reads as fine.
         gauge._handle("quota", _q(status="allowed", util=0.94))
-        assert gauge.ctx_lbl.cget("fg") == co.T["err"]
+        assert gauge._ring_arcs()["five_hour"][1] == co.T["err"]
 
     def test_context_keeps_its_own_tiers_in_the_fallback(self, gauge):
         gauge._ctx_pct = 90
@@ -118,6 +121,7 @@ class TestGaugeColour:
 
     def test_model_and_version_never_follow_the_gauge(self, gauge):
         gauge._model = "claude-opus-5"
+        gauge._ctx_pct = 90
         gauge._handle("quota", _q(status="rejected", util=1.0))
         assert gauge.ctx_lbl.cget("fg") == co.T["err"]
         assert gauge.statusline.cget("fg") == co.T["muted"]
@@ -125,6 +129,14 @@ class TestGaugeColour:
 
 
 class TestAnnouncements:
+
+    @pytest.fixture(autouse=True)
+    def _ring_already_introduced(self, gauge):
+        """The ring names itself once, on the first reading that arrives from either source.
+        That is not an announcement - it labels a piece of UI and claims nothing about status -
+        so it is stood down here to leave the transcript carrying only what _announce_quota
+        put there. TestTheRingIntroducesItself covers the introduction on its own."""
+        gauge._ring_explained = True
 
     def test_warning_says_when_it_comes_back_and_what_to_do(self, gauge):
         gauge._handle("quota", _q(status="allowed_warning", util=0.82))

--- a/tests/test_ui_quota_gauge.py
+++ b/tests/test_ui_quota_gauge.py
@@ -1,0 +1,402 @@
+# -*- coding: utf-8 -*-
+"""The allowance gauge when the reading came from usage.py's poll rather than the CLI.
+
+The CLI reports its rate-limit status only when that status TRANSITIONS, i.e. as a side
+effect of sending a message — so an overlay you have just opened, or one sitting idle, has
+nothing to put in the slot that tracks what actually ends a session. usage.py polls the
+same endpoint the CLI's own /usage screen reads and fills it in.
+
+What these tests pin is the SEPARATION between the two sources, because that's where a bug
+would be expensive rather than merely wrong: the polled reading is fresher and so wins the
+DISPLAY, but it must never reach anything that speaks to the user or that can put a message
+on the wire. It carries no status (usage.py won't invent one from the endpoint's severity
+vocabulary), so an announcement driven off it would be a guess, and a retry re-armed by it
+would send a refused message on a guess."""
+import time
+
+import pytest
+
+import claude_overlay as co
+from conftest import chat_text
+
+
+def polled(u=0.47, resets_at=None, window="five_hour"):
+    """A poll payload in usage.reading()'s shape: every window it saw, keyed by name. It no
+    longer mimics worker.py's single-window payload — that resemblance was what let
+    _gauge_quota `or` the two sources together as if they were one thing."""
+    return {"windows": {window: {"utilization": u, "resets_at": resets_at}}}
+
+
+POLLED = polled()
+
+
+@pytest.fixture
+def gauge(overlay):
+    """A clean statusline: no CLI reading, no polled reading, no context percentage, so
+    each test's gauge text comes only from what it puts in."""
+    ov = overlay
+    ov._quota = None
+    ov._quota_polled = None
+    ov._quota_said = None
+    ov._ctx_pct = None
+    ov._ctx_hist.clear()
+    ov._retry = None
+    return ov
+
+
+# ── the gap this closes: a number before the first message ─────────────────────────
+
+class TestPolledReadingReachesTheGauge:
+    """The gauge these fill is the ring on the ✻ mark, not the status row. The row gave the
+    quota up once the ring could show it — see TestTheRowGivesUpTheQuota — so the facts that
+    used to be read off _gauge_text are read off the ring and its hover text instead."""
+
+    def test_a_poll_alone_gives_the_gauge_an_allowance(self, gauge):
+        """Before this, an overlay that hadn't sent anything showed the size of the
+        conversation instead — a number that answers a different question."""
+        gauge._handle("quota_poll", POLLED)
+        assert gauge._ring_arcs()["five_hour"][0] == pytest.approx(0.47)
+
+    def test_it_reaches_the_mark_not_just_the_method(self, gauge):
+        gauge._handle("quota_poll", POLLED)
+        assert gauge._mark.find_withtag("ring")
+
+    def test_the_reset_time_comes_along(self, gauge):
+        soon = time.time() + 1800
+        gauge._handle("quota_poll", polled(resets_at=soon))
+        assert time.strftime("%H:%M", time.localtime(soon)) in gauge._usage_panel_text()
+
+    def test_a_fresher_poll_outranks_a_stale_cli_reading(self, gauge):
+        """The CLI's copy can be hours old — it only speaks on transitions — and hours old
+        is exactly the state this exists to fix."""
+        gauge._handle("quota", {"status": "allowed", "utilization": 0.20,
+                                "resets_at": None, "window": "five_hour"})
+        gauge._handle("quota_poll", POLLED)
+        assert gauge._ring_arcs()["five_hour"][0] == pytest.approx(0.47)
+
+    def test_the_cli_still_owns_the_gauge_when_nothing_has_been_polled(self, gauge):
+        gauge._handle("quota", {"status": "allowed", "utilization": 0.20,
+                                "resets_at": None, "window": "seven_day"})
+        assert gauge._ring_arcs()["week"][0] == pytest.approx(0.20)
+
+    def test_junk_payload_is_ignored(self, gauge):
+        for bad in (None, "nope", 47):
+            gauge._handle("quota_poll", bad)
+        assert gauge._quota_polled is None
+        assert gauge._ring_arcs() == {}
+
+    def test_colour_follows_the_number_shown(self, gauge):
+        """A polled reading has no status, so _QUOTA_HOT is what colours it. A grey 94%
+        reads as nothing being wrong."""
+        gauge._handle("quota_poll", polled(0.94))
+        assert gauge._ring_arcs()["five_hour"][1] == co.T["err"]
+        gauge._handle("quota_poll", polled(0.20))
+        assert gauge._ring_arcs()["five_hour"][1] == co.T["muted"]
+
+
+# ── the row gives the quota up to the ring ─────────────────────────────────────────
+
+class TestTheRowGivesUpTheQuota:
+    """Once the ring carries the allowance, printing it again below is the same number twice.
+    What the row keeps is context — the size of THIS conversation, which the ring says nothing
+    about — and it keeps it only while it is worth acting on."""
+
+    def test_the_quota_no_longer_takes_the_row(self, gauge):
+        gauge._handle("quota_poll", POLLED)
+        assert "quota" not in gauge.ctx_lbl.cget("text")
+
+    def test_the_row_is_down_to_one_number(self, gauge):
+        """This is the whole point: on a narrow overlay the row was carrying the model, the
+        quota, its reset time and the version, and the version was the one being clipped."""
+        gauge._ctx_pct = 15.0
+        gauge._handle("quota_poll", POLLED)
+        assert gauge.ctx_lbl.cget("text").strip() == "·   context 15%"
+
+    def test_context_keeps_the_slot_since_the_ring_never_shows_it(self, gauge):
+        """The ring is the plan allowance; context is the size of this conversation. Deleting
+        it alongside the quota would have dropped a number nothing else carries."""
+        gauge._ctx_pct = co._CTX_WARN_PCT + 5
+        gauge._refresh_statusline()
+        assert "context 75%" in gauge.ctx_lbl.cget("text")
+
+
+# ── the row holds still, the panel carries the detail ────────────────────
+
+class TestTheRowHoldsStill:
+    """The row is a fixed two items now. It used to grow a turns figure once a burn rate could
+    be read, and to swap itself out for the allowance while the mark was hovered - both make
+    the one strip of chrome that should be stable reflow while you are looking at it."""
+
+    def test_the_turns_figure_leaves_the_row(self, gauge):
+        gauge._ctx_pct = 40.0
+        gauge._ctx_hist.extend([10.0, 25.0, 40.0])
+        gauge._refresh_statusline()
+        assert "context 40%" in gauge.ctx_lbl.cget("text")
+        assert "turn" not in gauge.ctx_lbl.cget("text")
+
+    def test_the_row_does_not_change_under_the_cursor(self, gauge):
+        gauge._ctx_pct = 24.0
+        gauge._handle("quota_poll", WINS)
+        resting = gauge.ctx_lbl.cget("text")
+        gauge._mark_enter()
+        assert gauge.ctx_lbl.cget("text") == resting
+
+
+class TestTheHoverPanel:
+
+    def test_it_appears_on_the_mark_and_leaves_with_it(self, gauge):
+        gauge._handle("quota_poll", WINS)
+        gauge._mark_enter()
+        assert gauge._usage_panel.winfo_manager() == "place"
+        gauge._mark_leave()
+        assert gauge._usage_panel.winfo_manager() == ""
+
+    def test_it_carries_both_allowance_windows(self, gauge):
+        gauge._handle("quota_poll", WINS)
+        text = gauge._usage_panel_text()
+        assert "5h" in text and "25%" in text
+        assert "week" in text and "60%" in text
+
+    def test_it_carries_the_turns_the_row_gave_up(self, gauge):
+        gauge._ctx_pct = 40.0
+        gauge._ctx_hist.extend([10.0, 25.0, 40.0])
+        assert "context" in gauge._usage_panel_text()
+        assert "turn" in gauge._usage_panel_text()
+
+    def test_a_reset_time_travels_with_its_own_window(self, gauge):
+        soon = time.time() + 1800
+        gauge._handle("quota_poll", polled(resets_at=soon))
+        assert time.strftime("%H:%M", time.localtime(soon)) in gauge._usage_panel_text()
+
+    def test_it_says_so_when_there_is_nothing_to_report(self, gauge):
+        """A panel that opens empty reads as a broken control."""
+        assert gauge._usage_panel_text().strip()
+
+    def test_the_mark_is_actually_wired_to_the_handlers(self, gauge):
+        """The behaviour above is driven through _mark_enter directly - Tk will not dispatch
+        <Enter> to a widget that was never mapped - so the binding itself needs its own check,
+        along with the cursor that advertises the mark answers to something."""
+        assert gauge._mark.bind("<Enter>") and gauge._mark.bind("<Leave>")
+        assert gauge._mark.cget("cursor") == "hand2"
+
+    def test_it_lives_inside_the_overlay_window(self, gauge):
+        """NOT a Toplevel, deliberately. The capture exclusion that keeps the overlay out of
+        screen shares - and out of the screenshots we send Claude - is set on the root HWND
+        and is not inherited by a new top-level window. A tooltip in its own window would be
+        visible in a Teams share while the overlay itself was not, and would land inside our
+        own screenshots, because capture() skips its withdraw dance whenever the exclusion is
+        active. A child placed inside root inherits all of it for free."""
+        assert gauge._usage_panel.winfo_toplevel() is gauge.root
+
+
+# ── and it says what it is, once ───────────────────────────────────────────────────
+
+class TestTheRingIntroducesItself:
+
+    def test_the_first_reading_says_what_the_ring_is(self, gauge):
+        gauge._handle("quota_poll", POLLED)
+        assert "allowance" in chat_text(gauge)
+
+    def test_it_is_not_repeated_on_every_poll(self, gauge):
+        gauge._handle("quota_poll", POLLED)
+        after_first = chat_text(gauge)
+        gauge._handle("quota_poll", polled(0.60))
+        assert chat_text(gauge) == after_first
+
+    def test_nothing_is_said_when_there_is_no_reading_to_explain(self, gauge):
+        before = chat_text(gauge)
+        gauge._handle("quota_poll", {"windows": {}})
+        assert chat_text(gauge) == before
+
+
+# ── what a poll must NOT do ────────────────────────────────────────────────────────
+
+class TestPollIsDisplayOnly:
+
+    def test_a_poll_never_announces_a_status(self, gauge):
+        """Even at 99%. The warning's wording is about what to do on your next message, and it
+        belongs to a status the poll doesn't have.
+
+        The ring's one-time introduction is deliberately NOT a counter-example: it names a
+        piece of UI and claims nothing about severity, which is the thing this guards. It is
+        stood down here so this test watches the announcement path and only that."""
+        gauge._ring_explained = True
+        before = chat_text(gauge)
+        gauge._handle("quota_poll", polled(0.99))
+        assert chat_text(gauge) == before
+
+    def test_a_poll_does_not_consume_the_one_announcement_the_cli_gets(self, gauge):
+        """_quota_said is what makes each transition speak exactly once. If a poll could
+        overwrite it, the CLI's real warning would either be swallowed or repeated."""
+        gauge._handle("quota", {"status": "allowed_warning", "utilization": 0.92,
+                                "resets_at": None, "window": "five_hour"})
+        said_once = chat_text(gauge)
+        assert "allowance is spent" in said_once
+        gauge._handle("quota_poll", POLLED)
+        assert gauge._quota_said == "allowed_warning"
+        gauge._handle("quota", {"status": "allowed_warning", "utilization": 0.93,
+                                "resets_at": None, "window": "five_hour"})
+        assert chat_text(gauge) == said_once          # not said twice
+
+    def test_a_poll_cannot_release_an_armed_retry(self, gauge):
+        """An armed retry puts a previously refused message on the wire, quite possibly with
+        nobody at the machine. Only the CLI's own reading may decide the window reopened."""
+        gauge._quota = {"status": "rejected", "utilization": 1.0,
+                        "resets_at": time.time() + 3600, "window": "five_hour"}
+        gauge._retry = {"at": int(time.time() + 3600), "text": "hi", "armed": True}
+        gauge._handle("quota_poll", POLLED)
+        assert not gauge._retry.get("ready")
+
+    def test_the_cli_reading_still_releases_it(self, gauge):
+        """The other half of the previous test: this path must keep working."""
+        gauge._retry = {"at": int(time.time() + 3600), "text": "hi", "armed": True}
+        gauge._handle("quota", {"status": "allowed", "utilization": 0.1,
+                                "resets_at": None, "window": "five_hour"})
+        assert gauge._retry is None or gauge._retry.get("ready")
+
+    def test_an_announcement_quotes_its_own_window_s_reset_not_the_poll_s(self, gauge):
+        """The gauge and an announcement can legitimately be describing different windows.
+        Pairing 'your week allowance is used up' with the 5-hour window's reset time would
+        tell someone they can start again in half an hour when they can't."""
+        weekly_reset = time.time() + 3 * 86400
+        gauge._handle("quota_poll", polled(resets_at=time.time() + 1800))
+        gauge._handle("quota", {"status": "rejected", "utilization": 1.0,
+                                "resets_at": weekly_reset, "window": "seven_day"})
+        said = chat_text(gauge)
+        assert time.strftime("%a %H:%M", time.localtime(weekly_reset)) in said
+        assert "week allowance is used up" in said
+
+
+# ── wiring ─────────────────────────────────────────────────────────────────────────
+
+def test_the_overlay_builds_a_poller_and_stops_it_on_quit(overlay):
+    """conftest neuters Poller.start (no thread, no network), so what's asserted here is
+    that the Overlay owns one at all and that quit() tells it to stop."""
+    assert isinstance(overlay._usage_poll, co.usage.Poller)
+    overlay._usage_poll.stop()
+    assert overlay._usage_poll._stop.is_set()
+
+
+# ── the policy that used to live in usage.py ────────────────────────────────────────
+
+class TestBindingWindow:
+    """`_binding_window` holds the rule usage.reading() used to apply before the UI ever saw
+    the data: the binding constraint is the limit you reach first. It moved here because it is
+    a display decision, and because collapsing to it in the data layer threw away the 5-hour
+    window that the ring now needs to draw."""
+
+    def test_picks_the_window_that_is_furthest_along(self):
+        w = co._binding_window({"five_hour": {"utilization": 0.12},
+                                "seven_day": {"utilization": 0.71}})
+        assert w["window"] == "seven_day"
+        assert w["utilization"] == pytest.approx(0.71)
+
+    def test_a_tie_goes_to_five_hour(self):
+        """At equal percentages the 5-hour window is the one that can end the session you are
+        sitting in right now."""
+        w = co._binding_window({"seven_day": {"utilization": 0.40},
+                                "five_hour": {"utilization": 0.40}})
+        assert w["window"] == "five_hour"
+
+    def test_it_carries_the_window_s_own_reset_time(self):
+        w = co._binding_window({"five_hour": {"utilization": 0.5, "resets_at": 1788103800.0}})
+        assert w["resets_at"] == pytest.approx(1788103800.0)
+
+    def test_nothing_usable_is_none_not_a_crash(self):
+        for bad in (None, {}, {"five_hour": None}, {"five_hour": {}}):
+            assert co._binding_window(bad) is None, bad
+
+
+# ── the ring on the ✻ mark ──────────────────────────────────────────────────────────
+
+WINS = {"windows": {"five_hour": {"utilization": 0.25, "resets_at": None},
+                    "seven_day": {"utilization": 0.60, "resets_at": None}}}
+
+
+class TestRingArcs:
+    """What the ring is asked to draw, kept apart from the drawing. The mark is rendered as
+    one supersampled image (Tk's own create_arc has no antialiasing on Windows, and a 3px arc
+    on a 36px circle turns into a visible staircase), so the values and colours are worth
+    pinning somewhere a test can read them without decoding a bitmap."""
+
+    def test_each_track_carries_its_own_window(self, gauge):
+        gauge._handle("quota_poll", WINS)
+        arcs = gauge._ring_arcs()
+        assert arcs["five_hour"][0] == pytest.approx(0.25)
+        assert arcs["week"][0] == pytest.approx(0.60)
+
+    def test_the_five_hour_track_fills_even_while_the_week_is_further_along(self, gauge):
+        """The bug the ring exists to fix. Under the old single-slot rule this state — 5h
+        below the week, i.e. exactly where you are when you sit down to work — showed the
+        weekly number and left the 5-hour one off the wire entirely, so the window that
+        actually ends your session was invisible for its whole early stretch."""
+        gauge._handle("quota_poll", WINS)
+        assert "five_hour" in gauge._ring_arcs()
+
+    def test_a_spent_window_goes_red(self, gauge):
+        gauge._handle("quota_poll", {"windows": {"five_hour": {"utilization": 0.95}}})
+        assert gauge._ring_arcs()["five_hour"][1] == co.T["err"]
+
+    def test_a_window_past_the_warning_line_goes_amber(self, gauge):
+        gauge._handle("quota_poll", {"windows": {"five_hour": {"utilization": 0.80}}})
+        assert gauge._ring_arcs()["five_hour"][1] == co.T["accent"]
+
+    def test_a_quiet_window_stays_recessive(self, gauge):
+        gauge._handle("quota_poll", WINS)
+        assert gauge._ring_arcs()["five_hour"][1] == co.T["muted"]
+
+    def test_the_week_track_shows_the_hottest_of_the_per_model_windows(self, gauge):
+        """seven_day, seven_day_opus and seven_day_sonnet reset on the same weekly clock, so
+        they are one constraint with three faces; the face nearest its limit owns the track."""
+        gauge._handle("quota_poll", {"windows": {"seven_day": {"utilization": 0.20},
+                                                 "seven_day_opus": {"utilization": 0.80}}})
+        assert gauge._ring_arcs()["week"][0] == pytest.approx(0.80)
+
+    def test_an_untouched_window_gets_no_arc_at_all(self, gauge):
+        """A hairline at 0% would read as "something is used"."""
+        gauge._handle("quota_poll", {"windows": {"five_hour": {"utilization": 0.0}}})
+        assert "five_hour" not in gauge._ring_arcs()
+
+    def test_a_cli_reading_that_names_its_window_still_fills_its_track(self, gauge):
+        """An overlay whose CLI has spoken but whose poll hasn't landed yet is not blank."""
+        gauge._handle("quota", {"status": "allowed", "utilization": 0.5,
+                                "resets_at": None, "window": "five_hour"})
+        assert gauge._ring_arcs()["five_hour"][0] == pytest.approx(0.5)
+
+    def test_an_unplaceable_reading_fills_nothing_rather_than_guessing(self, gauge):
+        """A window with no name can't be put on a track without claiming it is one of the
+        two we drew. The statusline text still carries the number, so silence costs nothing."""
+        gauge._handle("quota", {"status": "allowed", "utilization": 0.5,
+                                "resets_at": None, "window": None})
+        assert gauge._ring_arcs() == {}
+
+    def test_the_track_is_visible_against_the_background(self, gauge):
+        """T["border"] is 1.2:1 against the surface — right for a hairline between panels,
+        invisible as an empty gauge, which is why the first cut of this showed nothing at all
+        on a fresh overlay."""
+        assert co._contrast(gauge._ring_track(), co.T["bg"]) >= 1.6
+
+
+class TestRingRendering:
+
+    def test_the_mark_carries_exactly_one_image(self, gauge):
+        gauge._handle("quota_poll", WINS)
+        ids = gauge._mark.find_withtag("ring")
+        assert len(ids) == 1
+        assert gauge._mark.type(ids[0]) == "image"
+
+    def test_the_photo_is_kept_referenced_so_tk_cannot_collect_it(self, gauge):
+        """Tk holds only a weak claim on a PhotoImage; drop the Python reference and the mark
+        silently goes blank. Same reason _orb_name_photo is kept on the instance."""
+        gauge._handle("quota_poll", WINS)
+        assert gauge._ring_photo is not None
+
+    def test_a_repaint_replaces_the_image_instead_of_stacking(self, gauge):
+        gauge._handle("quota_poll", WINS)
+        gauge._handle("quota_poll", WINS)
+        assert len(gauge._mark.find_withtag("ring")) == 1
+
+    def test_an_overlay_with_no_reading_still_draws_its_empty_tracks(self, gauge):
+        """The mark is always the mark; the tracks are what make a filled arc read as "this
+        much of that" rather than as a stray fragment."""
+        assert len(gauge._mark.find_withtag("ring")) == 1

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -1,0 +1,340 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for usage.py - the plan-allowance poll that fills the statusline gauge.
+
+Nothing here touches the network or this machine's real login: every test either points
+CLAUDE_CONFIG_DIR at a tmp dir or monkeypatches the fetch. Two themes get tested harder
+than the happy path, because they are the module's actual promises:
+
+  * DEGRADATION - every failure (no file, alt auth, expired token, HTTP error, junk JSON,
+    an endpoint that changed shape) must come back as None rather than raise, because a
+    poll runs on a timer inside a running app and must never be able to break it;
+  * THE TOKEN NEVER ESCAPES - it goes in one Authorization header and nowhere else, and in
+    particular it is never handed to the debug log.
+"""
+
+import json
+import time
+
+import pytest
+
+import authstate
+import usage
+
+
+LIVE = {"accessToken": "at-live", "refreshToken": "rt-live",
+        "expiresAt": (time.time() + 3600) * 1000}       # the CLI writes ms since epoch
+
+
+@pytest.fixture
+def cfgdir(tmp_path, monkeypatch):
+    """An isolated CLI config dir, with every alternative-auth env var cleared so this
+    machine's real ANTHROPIC_API_KEY (etc.) can't make the poller stand down."""
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+    for name in authstate._ALT_AUTH_ENV:
+        monkeypatch.delenv(name, raising=False)
+    return tmp_path
+
+
+def write_creds(d, oauth):
+    (d / ".credentials.json").write_text(json.dumps({"claudeAiOauth": oauth}), encoding="utf-8")
+
+
+# ── _epoch: the endpoint speaks ISO-8601, the UI clock speaks epoch seconds ──────────
+
+class TestEpoch:
+
+    def test_offset_stamp_is_converted(self):
+        # The exact shape the endpoint returns, microseconds and all.
+        assert usage._epoch("2026-08-30T15:30:00.133934+00:00") == pytest.approx(1788103800.13, abs=0.1)
+
+    def test_military_z_is_accepted(self):
+        """fromisoformat can't read a trailing Z before 3.11 and the floor is 3.10, so the
+        module normalises it. Same instant either way."""
+        assert usage._epoch("2026-08-30T15:30:00Z") == usage._epoch("2026-08-30T15:30:00+00:00")
+
+    def test_naive_stamp_is_read_as_utc(self):
+        assert usage._epoch("2026-08-30T15:30:00") == usage._epoch("2026-08-30T15:30:00+00:00")
+
+    def test_numbers_pass_through_and_junk_is_none(self):
+        assert usage._epoch(1788103800) == 1788103800.0
+        for bad in (None, "", "   ", "not a date", [], {}, True):
+            assert usage._epoch(bad) is None, bad
+
+
+# ── reading(): every window, and no opinion about which one matters ─────────────
+
+class TestReading:
+
+    def test_every_window_is_reported_not_just_the_one_that_binds(self):
+        """The old contract collapsed to the furthest-along window before the UI ever saw the
+        data, so a 5-hour window sitting below the weekly one was simply not available to
+        draw — and the 5-hour is the one that ends the session you are in. Which window earns
+        a slot is a DISPLAY policy; this module's job is to report what the endpoint said."""
+        r = usage.reading({"five_hour": {"utilization": 12.0, "resets_at": None},
+                           "seven_day": {"utilization": 71.0, "resets_at": None}})
+        assert set(r["windows"]) == {"five_hour", "seven_day"}
+        assert r["windows"]["five_hour"]["utilization"] == pytest.approx(0.12)
+        assert r["windows"]["seven_day"]["utilization"] == pytest.approx(0.71)
+
+    def test_no_window_is_singled_out_here(self):
+        """No top-level utilization/window pair any more — that pair WAS the policy. Keeping
+        a copy beside `windows` would be the same number in two places, free to drift the
+        first time the rule that picks it changes."""
+        r = usage.reading({"five_hour": {"utilization": 12.0},
+                           "seven_day": {"utilization": 71.0}})
+        assert "utilization" not in r
+        assert "window" not in r
+
+    def test_utilization_is_rescaled_to_the_sdk_s_0_to_1(self):
+        """The endpoint says 47.0 for 47%; the SDK says 0.47; the UI multiplies by 100. If
+        this ever stopped dividing, the gauge would read 4700%."""
+        r = usage.reading({"five_hour": {"utilization": 47.0}})
+        assert r["windows"]["five_hour"]["utilization"] == pytest.approx(0.47)
+
+    def test_per_model_weekly_windows_are_eligible(self):
+        r = usage.reading({"five_hour": {"utilization": 3.0},
+                           "seven_day_opus": {"utilization": 90.0}})
+        assert set(r["windows"]) == {"five_hour", "seven_day_opus"}
+
+    def test_status_is_never_invented(self):
+        """The endpoint's severity vocabulary is the server's. usage.py refuses to guess at
+        it, so nothing downstream can announce a warning off a polled reading."""
+        w = usage.reading({"five_hour": {"utilization": 99.0}})["windows"]["five_hour"]
+        assert "status" not in w
+
+    def test_resets_at_is_carried_as_epoch_seconds(self):
+        r = usage.reading({"five_hour": {"utilization": 5.0,
+                                         "resets_at": "2026-08-30T15:30:00+00:00"}})
+        assert r["windows"]["five_hour"]["resets_at"] == pytest.approx(1788103800.0)
+
+    def test_one_unusable_window_does_not_discard_the_others(self):
+        """Windows are reported independently, so junk in one is not a reason to lose a
+        good reading for another."""
+        r = usage.reading({"five_hour": {"utilization": "47"},
+                           "seven_day": {"utilization": 30.0}})
+        assert set(r["windows"]) == {"seven_day"}
+
+    def test_unusable_shapes_are_none_not_a_crash(self):
+        for bad in (None, [], "nope", {}, {"five_hour": None}, {"five_hour": {}},
+                    {"five_hour": {"utilization": None}},
+                    {"five_hour": {"utilization": "47"}},
+                    {"seven_day_cowork": {"utilization": 80.0}}):   # a window the UI can't label
+            assert usage.reading(bad) is None, bad
+
+    def test_a_bool_utilization_is_not_a_number(self):
+        """True == 1 in Python, which would quietly render as "quota 100%"."""
+        assert usage.reading({"five_hour": {"utilization": True}}) is None
+
+
+# ── _access_token: every "don't ask" case collapses to None ─────────────────────────
+
+class TestAccessToken:
+
+    def test_reads_the_cli_s_token(self, cfgdir):
+        write_creds(cfgdir, LIVE)
+        assert usage._access_token() == "at-live"
+
+    def test_alt_auth_stands_down(self, cfgdir, monkeypatch):
+        """Bedrock / Vertex / API-key accounts have no plan allowance for this endpoint to
+        report, so the poll shouldn't even read the file."""
+        write_creds(cfgdir, LIVE)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-whatever")
+        assert usage._access_token() is None
+
+    def test_expired_token_is_skipped_not_refreshed(self, cfgdir):
+        """Token lifecycle stays the CLI's job. Skipping costs one stat() and picks the
+        refreshed token up on the next tick."""
+        write_creds(cfgdir, dict(LIVE, expiresAt=(time.time() - 60) * 1000))
+        assert usage._access_token() is None
+
+    def test_blank_and_missing_and_unreadable_are_none(self, cfgdir):
+        assert usage._access_token() is None                       # no file at all (keychain)
+        write_creds(cfgdir, dict(LIVE, accessToken=""))            # the CLI's dead-login marker
+        assert usage._access_token() is None
+        (cfgdir / ".credentials.json").write_text("{ not json", encoding="utf-8")
+        assert usage._access_token() is None
+        (cfgdir / ".credentials.json").write_text(json.dumps({"other": 1}), encoding="utf-8")
+        assert usage._access_token() is None
+
+    def test_absurdly_large_file_is_not_slurped(self, cfgdir):
+        (cfgdir / ".credentials.json").write_text("x" * (usage._MAX_CRED_BYTES + 1),
+                                                  encoding="utf-8")
+        assert usage._access_token() is None
+
+
+# ── _fetch: where the token goes, and what happens when the call fails ──────────────
+
+class _FakeResp:
+    def __init__(self, body):
+        self._body = body
+    def read(self, n=None):
+        return self._body
+    def __enter__(self):
+        return self
+    def __exit__(self, *a):
+        return False
+
+
+def _capture_urlopen(monkeypatch, body=b'{"five_hour": {"utilization": 5.0}}'):
+    seen = {}
+    def fake(req, timeout=None):
+        seen["url"] = req.full_url
+        seen["headers"] = {k.lower(): v for k, v in req.header_items()}
+        seen["method"] = req.get_method()
+        seen["timeout"] = timeout
+        return _FakeResp(body)
+    monkeypatch.setattr(usage.urllib.request, "urlopen", fake)
+    return seen
+
+
+class TestFetch:
+
+    def test_token_goes_to_anthropic_in_one_get_header(self, monkeypatch):
+        seen = _capture_urlopen(monkeypatch)
+        assert usage._fetch("at-secret") == {"five_hour": {"utilization": 5.0}}
+        assert seen["url"] == "https://api.anthropic.com/api/oauth/usage"
+        assert seen["method"] == "GET"                     # cannot spend, change or send
+        assert seen["headers"]["authorization"] == "Bearer at-secret"
+        # ...and nowhere else: no other header repeats it.
+        others = [v for k, v in seen["headers"].items() if k != "authorization"]
+        assert not any("at-secret" in str(v) for v in others)
+        assert "at-secret" not in seen["url"]
+
+    def test_http_error_is_none_and_logs_the_code_only(self, monkeypatch):
+        """A failed auth call's body is the one place a server might echo the request back.
+        The module's safety story is that the token never reaches disk, so the log gets a
+        status code and nothing else."""
+        import urllib.error
+        logged = []
+        monkeypatch.setattr(usage, "dbg", lambda kind, payload=None: logged.append(str(payload)))
+        def boom(req, timeout=None):
+            raise urllib.error.HTTPError(usage._URL, 401, "Unauthorized", {}, None)
+        monkeypatch.setattr(usage.urllib.request, "urlopen", boom)
+        assert usage._fetch("at-secret") is None
+        assert logged and "401" in logged[0]
+        assert not any("at-secret" in line for line in logged)
+
+    def test_transport_failure_is_none(self, monkeypatch):
+        def boom(req, timeout=None):
+            raise OSError("offline")
+        monkeypatch.setattr(usage.urllib.request, "urlopen", boom)
+        assert usage._fetch("at-live") is None
+
+    def test_non_dict_or_unparseable_body_is_none(self, monkeypatch):
+        _capture_urlopen(monkeypatch, body=b"[1, 2, 3]")
+        assert usage._fetch("at-live") is None
+        _capture_urlopen(monkeypatch, body=b"<html>proxy login</html>")
+        assert usage._fetch("at-live") is None
+
+
+# ── poll_once: no token means no request at all ────────────────────────────────────
+
+def test_poll_once_without_a_token_never_calls_out(monkeypatch):
+    monkeypatch.setattr(usage, "_access_token", lambda: None)
+    monkeypatch.setattr(usage, "_fetch", lambda *a, **k: pytest.fail("must not fetch"))
+    assert usage.poll_once() is None
+
+
+def test_poll_once_end_to_end(monkeypatch):
+    monkeypatch.setattr(usage, "_access_token", lambda: "at-live")
+    monkeypatch.setattr(usage, "_fetch", lambda tok: {"five_hour": {"utilization": 47.0}})
+    assert usage.poll_once()["windows"]["five_hour"]["utilization"] == pytest.approx(0.47)
+
+
+# ── Poller: what it puts on the queue, and how long it waits ───────────────────────
+
+class _FakeStop:
+    """Stands in for the stop Event so the schedule can be tested without sleeping: records
+    every wait() it's asked for and ends the loop after `stop_after` of them."""
+
+    def __init__(self, stop_after):
+        self.waits = []
+        self.stop_after = stop_after
+
+    def wait(self, t):
+        self.waits.append(t)
+        return len(self.waits) > self.stop_after
+
+    def set(self):
+        self.stop_after = 0
+
+
+def _drive(monkeypatch, results, ticks):
+    """Run Poller._run for `ticks` iterations against a scripted poll_once."""
+    import queue as _q
+    seq = list(results)
+    monkeypatch.setattr(usage, "poll_once", lambda: seq.pop(0) if seq else None)
+    p = usage.Poller(_q.Queue(), interval=60, first_delay=2.0, fail_delay=300)
+    p._stop = _FakeStop(ticks)
+    p._run()
+    return p
+
+
+class TestPoller:
+
+    def test_a_real_reading_survives_the_trip_to_the_queue(self, monkeypatch):
+        """Regression: the poll loop logged r["utilization"], a key reading() stopped
+        emitting when it began reporting every window. The KeyError landed OUTSIDE the
+        try around poll_once and BEFORE the put, so the daemon thread died on its first
+        successful poll and the overlay never saw an allowance again — it silently fell
+        back to showing context. Every other Poller test scripted its own payload, so
+        none of them ever put a real reading() through this loop."""
+        real = usage.reading({"five_hour": {"utilization": 38.0, "resets_at": None}})
+        p = _drive(monkeypatch, [real], ticks=1)
+        assert p.ui.get_nowait() == ("quota_poll", real)
+
+    def test_emits_readings_on_the_ui_queue(self, monkeypatch):
+        r = usage.reading({"five_hour": {"utilization": 47.0}})
+        p = _drive(monkeypatch, [r], ticks=1)
+        assert p.ui.get_nowait() == ("quota_poll", r)
+
+    def test_a_failed_poll_does_not_blank_the_last_reading(self, monkeypatch):
+        """Allowance isn't spent while the request is failing, so the previous number is
+        still the best one available. Emitting None would trade slightly-stale for nothing."""
+        p = _drive(monkeypatch, [None, None], ticks=2)
+        assert p.ui.empty()
+
+    def test_first_reading_is_asked_for_promptly_then_paced(self, monkeypatch):
+        r = {"status": None, "utilization": 0.1, "resets_at": None, "window": "five_hour"}
+        p = _drive(monkeypatch, [r, r], ticks=2)
+        assert p._stop.waits[0] == 2.0            # don't make the user wait a minute for it
+        assert p._stop.waits[1] == 60             # then the endpoint's own refresh cadence
+
+    def test_a_failure_backs_off(self, monkeypatch):
+        """The common no-reading case is an account with no OAuth allowance at all, which
+        will never start working - retrying that at 60s forever is pure noise."""
+        p = _drive(monkeypatch, [None], ticks=2)
+        assert p._stop.waits[1] == 300
+
+    def test_an_exception_from_poll_once_is_survivable(self, monkeypatch):
+        import queue as _q
+        def boom():
+            raise RuntimeError("unexpected")
+        monkeypatch.setattr(usage, "poll_once", boom)
+        p = usage.Poller(_q.Queue(), interval=60, first_delay=0.0, fail_delay=300)
+        p._stop = _FakeStop(1)
+        p._run()                                   # must not raise out of the thread
+        assert p.ui.empty()
+
+    def test_start_is_idempotent(self, monkeypatch):
+        import queue as _q
+        started = []
+        class _FakeThread:
+            def __init__(self, **kw):
+                started.append(kw.get("name"))
+            def start(self):
+                pass
+        monkeypatch.setattr(usage.threading, "Thread", lambda **kw: _FakeThread(**kw))
+        p = usage.Poller(_q.Queue())
+        p.start()
+        p.start()
+        assert started == ["usage-poll"]           # never two threads on one account
+
+    def test_stop_ends_the_loop_without_waiting_out_the_interval(self):
+        """Real Event, real loop, one tick: quit() must not block on a 60s sleep."""
+        import queue as _q
+        p = usage.Poller(_q.Queue(), interval=600, first_delay=600)
+        p.stop()
+        started = time.monotonic()
+        p._run()                                   # set() already → wait() returns at once
+        assert time.monotonic() - started < 1.0

--- a/usage.py
+++ b/usage.py
@@ -1,0 +1,269 @@
+# -*- coding: utf-8 -*-
+"""Read the plan allowance directly, so the gauge is right BEFORE anything is sent.
+
+WHY THIS EXISTS
+worker.py's `_emit_quota` carries the only number that tracks what actually ENDS a session
+- but it arrives only when the CLI's rate-limit status TRANSITIONS, which is a side effect
+of sending a message. Open the overlay and just sit there and the statusline has nothing to
+put in that slot, so it falls back to the size of the conversation: a number that answers a
+different question (claude_overlay's "how much of the allowance is left" note spells out
+why those two are unrelated). The moment you most want to know whether you can start
+something is before you've started it, and that is exactly the moment the CLI has told us
+nothing. Today the answer lives on a settings page in a browser, which is a strange place to
+keep it when the overlay is already on top of everything else.
+
+This module fills the gap by asking the same endpoint the CLI's own /usage screen reads,
+`GET /api/oauth/usage`, on a timer.
+
+CREDENTIALS - A DELIBERATE, NARROW EXCEPTION TO authstate.py's DOCTRINE
+authstate.py opens with "the overlay owns no credentials ... the overlay never sees a
+token", and until now that was literally true. Polling breaks it: a bearer token is the only
+way to ask, and the CLI exposes no offline command that would answer instead (there is no
+`claude usage` subcommand; /usage is interactive-only). So the exception is drawn as
+narrowly as it can be, and it is worth stating what it does NOT permit:
+
+  * the token is re-read from the CLI's own file on every poll, kept in a local, handed to
+    one request and dropped. It is never stored on an object, never persisted, never logged
+    - the debug line carries a percentage and a window name, nothing else;
+  * it is sent to api.anthropic.com and nowhere else. The host is a module constant, not
+    configuration, so no settings file or env var can redirect a token somewhere new;
+  * the request is a GET. Nothing here can spend allowance, change an account setting, or
+    put a message on the wire;
+  * nothing is ever refreshed. An expired token is skipped, not renewed. Token lifecycle
+    stays entirely the CLI's business - a refresh race is precisely how a stored login gets
+    poisoned (see authstate's note on the CLI's compare-and-swap).
+
+DISPLAY ONLY, ON PURPOSE
+The reading produced here is deliberately weaker than the CLI's. It carries no status
+string: the endpoint's severity vocabulary belongs to the server, and guessing at its values
+would be putting words in its mouth - so the UI colours by the number instead, which is what
+_gauge_color already does at _QUOTA_HOT. Every path that SPEAKS to the user or that can send
+something - the allowance warning, the armed retry - still reads the CLI's own event and is
+untouched by this file. The worst failure available here is a percentage a minute out of
+date; it can never be a wrong action.
+
+Leaf module: the stdlib, plus authstate (for the credential path, and to know when another
+auth source means there is no plan allowance to report) and debuglog - both of which import
+nothing but the stdlib themselves. Every function degrades to None on ANY failure - offline,
+a corporate proxy, a keychain-backed login with no file at all, an endpoint that changed
+shape - so a poll can never break a running overlay: the statusline simply goes on doing
+what it did before this module existed.
+"""
+
+import json
+import threading
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+
+import authstate
+from debuglog import dbg
+
+_URL = "https://api.anthropic.com/api/oauth/usage"
+_BETA = "oauth-2025-04-20"              # the OAuth beta header the CLI sends on this call
+_UA = "claude-overlay"                  # honest, and accepted: the endpoint doesn't care
+_TIMEOUT_S = 12
+_MAX_BODY = 512 * 1024                  # the real response is ~2KB; never slurp something huge
+_MAX_CRED_BYTES = 256 * 1024            # mirrors authstate's cap on the same file
+
+POLL_S = 60                             # the endpoint's own figure is ~a minute stale (its web
+                                        # page says "last updated 1 minute ago"), so asking
+                                        # faster buys nothing but requests
+FAIL_S = 300                            # after a poll that produced nothing. Covers the common
+                                        # case of "this account has no OAuth allowance at all"
+                                        # (Bedrock / Vertex / API key) without spinning on it
+
+# The windows worth showing, in tie-break order - the same names claude_overlay's
+# _QUOTA_WINDOWS knows how to label, because a window it can't name would render bare.
+_WINDOWS = ("five_hour", "seven_day", "seven_day_opus", "seven_day_sonnet")
+
+
+def _access_token():
+    """The CLI's current OAuth access token, or None when there isn't a usable one.
+
+    None deliberately covers every "don't ask" case at once: another auth source is
+    configured (Bedrock / Vertex / API key - those accounts have no plan allowance for this
+    endpoint to report), the file is absent because the tokens live in an OS keychain, or the
+    token on disk has already expired.
+
+    Expiry is checked here rather than by letting the server answer 401, because the CLI
+    rewrites this file every time it refreshes: skipping this tick and re-reading the next
+    one picks the new token up within a minute, for the cost of one stat().
+    """
+    if authstate.alt_auth_configured():
+        return None
+    try:
+        p = authstate.credentials_path()
+        if p.stat().st_size > _MAX_CRED_BYTES:
+            return None
+        with open(p, "r", encoding="utf-8", errors="replace") as fh:
+            oauth = json.load(fh).get("claudeAiOauth")
+        tok = oauth.get("accessToken")
+        exp = oauth.get("expiresAt")              # ms since epoch, as the CLI writes it
+        if not isinstance(tok, str) or not tok:
+            return None
+        if isinstance(exp, (int, float)) and exp > 0 and exp / 1000.0 <= time.time():
+            return None
+        return tok
+    except Exception:
+        return None
+
+
+def _fetch(token, timeout=_TIMEOUT_S):
+    """The endpoint's raw JSON as a dict, or None on any failure.
+
+    An HTTPError is logged by CODE only. The body of a failed auth call is the one place a
+    server might echo something about the request back, and this module's whole safety story
+    is that the token never reaches disk - so it doesn't get to reach the log either.
+    """
+    req = urllib.request.Request(_URL, headers={
+        "Authorization": "Bearer " + token,
+        "anthropic-beta": _BETA,
+        "Accept": "application/json",
+        "User-Agent": _UA,
+    })
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            body = r.read(_MAX_BODY)
+        data = json.loads(body.decode("utf-8", "replace"))
+        return data if isinstance(data, dict) else None
+    except urllib.error.HTTPError as e:
+        dbg("usage", "http %s" % getattr(e, "code", "?"))
+        return None
+    except Exception as e:
+        dbg("usage", "fetch failed: %s" % type(e).__name__)
+        return None
+
+
+def _epoch(ts):
+    """An ISO-8601 timestamp from the endpoint as epoch SECONDS, or None.
+
+    Converted here so exactly one shape of reading ever reaches the UI: the SDK hands
+    worker.py epoch seconds, and both the statusline clock and the retry scheduler assume it.
+    A tz-naive stamp is read as UTC, which is what the endpoint means; a `Z` suffix is
+    normalised because fromisoformat can't read it before Python 3.11 and the floor is 3.10.
+    """
+    if isinstance(ts, bool):
+        return None
+    if isinstance(ts, (int, float)):
+        return float(ts)
+    if not isinstance(ts, str) or not ts.strip():
+        return None
+    try:
+        s = ts.strip()
+        if s[-1] in ("Z", "z"):
+            s = s[:-1] + "+00:00"
+        d = datetime.fromisoformat(s)
+        if d.tzinfo is None:
+            d = d.replace(tzinfo=timezone.utc)
+        return d.timestamp()
+    except Exception:
+        return None
+
+
+def reading(data):
+    """Every window the endpoint reported, rescaled, or None when it reported nothing usable.
+
+    NO WINDOW IS PICKED HERE, ON PURPOSE. This function used to collapse the endpoint's five
+    windows down to whichever was furthest along, on the reasoning that the statusline has a
+    single slot. Two things were wrong with that.
+
+    The first is a bug the user felt: the 5-hour window and the weekly one are not the same
+    kind of number. The weekly one climbs slowly in the background; the 5-hour one can go from
+    10% to spent in one afternoon, and it is the one that ends the session you are sitting in.
+    Ranking them by magnitude means that while the 5-hour window is below the weekly one -
+    which is exactly the state you are in when you sit down to work - the UI is showing the
+    number that will not bite, and the one that will is not even on the wire. It becomes
+    visible only after overtaking, so the whole early stretch of a 5-hour window went unseen.
+
+    The second is that picking is editorial, and this module's stated position is that it does
+    not editorialise: `status` stays None because the endpoint's severity vocabulary belongs to
+    the server and guessing at its values would be putting words in its mouth. Choosing which
+    of five windows deserves the user's attention is the same kind of guess, made on the same
+    kind of authority. "Which window earns the slot" is a display policy, so it now lives with
+    the display - see claude_overlay._binding_window, which holds the rule this used to apply.
+
+    utilization is rescaled to 0-1: this endpoint reports 47.0 for 47%, the SDK reports 0.47,
+    and the UI multiplies by 100. Windows are read independently, so one malformed entry costs
+    only itself; a window _WINDOWS doesn't name is dropped, because the UI would render it bare.
+    """
+    if not isinstance(data, dict):
+        return None
+    out = {}
+    for name in _WINDOWS:
+        w = data.get(name)
+        if not isinstance(w, dict):
+            continue
+        u = w.get("utilization")
+        if isinstance(u, bool) or not isinstance(u, (int, float)):
+            continue
+        out[name] = {"utilization": float(u) / 100.0, "resets_at": _epoch(w.get("resets_at"))}
+    return {"windows": out} if out else None
+
+
+def poll_once():
+    """One end-to-end reading, or None. Every failure above collapses to None right here, so
+    a caller never has to know which of them happened."""
+    tok = _access_token()
+    if not tok:
+        return None
+    return reading(_fetch(tok))
+
+
+class Poller:
+    """A daemon thread that puts ("quota_poll", reading) on the UI queue on a timer.
+
+    Emits readings ONLY, never a None: a failed poll must not blank a number that was right a
+    minute ago. Allowance isn't spent while the request is failing, so the previous reading
+    is still the best answer available - dropping it would trade a slightly stale number for
+    no number, which is the state this module exists to end.
+
+    Stopping is an Event, not a flag, so quit() doesn't have to wait out a sleep: wait()
+    returns the moment it's set. The thread is a daemon besides, so even a wedged socket
+    can't keep the process alive after the window closes.
+    """
+
+    def __init__(self, ui_queue, interval=POLL_S, first_delay=2.0, fail_delay=FAIL_S):
+        self.ui = ui_queue
+        self.interval = interval
+        self.first_delay = first_delay      # short: the first reading is the point of all this
+        self.fail_delay = fail_delay
+        self._stop = threading.Event()
+        self._thread = None
+
+    def start(self):
+        """Idempotent - a second call can't leave two threads polling the same account."""
+        if self._thread is not None:
+            return
+        self._thread = threading.Thread(target=self._run, name="usage-poll", daemon=True)
+        self._thread.start()
+
+    def stop(self):
+        self._stop.set()
+
+    def _run(self):
+        wait = self.first_delay
+        while not self._stop.wait(wait):
+            try:
+                r = poll_once()
+            except Exception:               # belt-and-braces: poll_once already swallows
+                r = None
+            if r:
+                # The reading goes on the queue FIRST, and the log line is guarded. It used to
+                # be the other way round, with the formatting bare: `r["utilization"]` outside
+                # any try, above the put. When reading() stopped emitting that key the KeyError
+                # killed this daemon thread on its first successful poll, so the overlay never
+                # saw an allowance again and silently fell back to showing context size. A line
+                # that exists to describe the work must never be able to cost the work.
+                try:
+                    self.ui.put(("quota_poll", r))
+                except Exception:
+                    pass
+                try:
+                    dbg("usage", "windows " + " ".join(
+                        "%s=%.2f" % (k, w.get("utilization", -1))
+                        for k, w in (r.get("windows") or {}).items()))
+                except Exception:
+                    pass
+            wait = self.interval if r else self.fail_delay


### PR DESCRIPTION
The statusline had grown to the point where the version number was being clipped. The allowance
was the biggest thing in it, and it was also the thing least suited to being a sentence — it's one
ratio against a limit, read at a glance, many times an hour. So it moved onto the ✻ mark as a
gauge, and the row it left behind now holds still.

## Two arcs, not one

The old line collapsed the windows down to whichever was furthest along, on the theory that the
number that stops you first is the only one worth the slot. That reasoning is right for a single
slot and wrong for a gauge. The 5-hour window is the one that ends the session you're actually in,
and it spends most of its life sitting *below* the weekly number — so "furthest along" hid it for
exactly as long as it mattered, and surfaced it only once it was too late to pace against.

Both are drawn now: inner arc is the 5-hour window, outer is weekly. Amber at 75%, red once spent.

That meant `usage.reading()` had to stop picking. It now reports every window the endpoint
returned, and the choice of *which one gets the accent colour* moved up into the UI, where a
presentation decision belongs. `_binding_window()` came with it.

## Making a 36px ring legible

Tk's `create_arc` has no antialiasing on Windows. Rendered at 1× the first attempt was unusable —
the ✻ was destroyed, the two arcs were indistinguishable, and an idle arc came out one pixel wide
and looked dashed. The ring is now drawn into a PIL image at 4× and LANCZOS-downsampled, which is
also why the mark grew from 24px to 36px (the titlebar is 44px, so there's room).

The track had a related problem: `T["border"]` measures 1.23:1 against the background in the light
theme. It's now `_mix(bg, faint, 0.70)` at 1.76:1 / 2.10:1, and there's a test computing the WCAG
ratio so it can't quietly regress again.

## An unlabelled gauge has to explain itself

Nothing about two arcs says "token allowance" to someone seeing it for the first time. Three things
answer that, none of which cost the row any space:

- the mark takes a `hand2` cursor, so it reads as something you can touch;
- **hovering it** drops a panel with both windows, their reset times, and context headroom in turns;
- the first time a reading lands, one system line says what the ring is.

The panel is a `Label` placed inside the root window rather than a `Toplevel`, deliberately —
`WDA_EXCLUDEFROMCAPTURE` is set on the root HWND and is *not* inherited by new top-level windows,
so a tooltip Toplevel would have been the one part of the overlay that shows up in a screen share.
There's a test pinning it to `root`.

## A polling thread that died on success

Found by looking at the running app after the gauge stopped appearing. The debug line in
`Poller._run` formatted `r["utilization"]` bare, outside any try, *above* the `put`. Once
`reading()` stopped emitting that key, the first successful poll raised `KeyError` and killed the
daemon thread — so the overlay never saw an allowance again and silently fell back to context size.

Fixed structurally rather than by adding a key: the reading goes on the queue first and the log line
is guarded. Every `Poller` test scripted its own fake payload, which is why none of them caught a
mismatch between the real `reading()` and the real logger; there's now a test that sends a genuine
`reading()` through the queue.

## The row

```
claude-opus-5 ▾ ·  context 24% ·  v1.18.0
```

Fixed width, never reflows. `~76 turns` moved into the hover panel — it's the kind of number you
want when you go looking for it, not one that should be resizing the bar every few turns.

## Verification

`861 passed`, `preflight.py` exits 0. Beyond the suite, the arcs were rendered to PNG and looked at
— the first design was rejected that way, not by a failing assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
